### PR TITLE
feat: Add support for fire-and-forget client tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ val config = ConversationConfig(
     // List of client tools the agent can invoke
     clientTools = mapOf(
         "logMessage" to object : ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
                 val message = parameters["message"] as? String
 
                 Log.d("ExampleApp", "[INFO] Client Tool Log: $message")
@@ -113,6 +113,8 @@ val config = ConversationConfig(
         }
     ),
 )
+
+> **Note:** If a tool is configured with `expects_response=false` on the server, return `null` from `execute` to skip sending a tool result back to the agent.
 
 // In an Activity context
 val session: ConversationSession = ConversationClient.startSession(config, this)
@@ -165,10 +167,10 @@ val config = ConversationConfig(
     agentId = "<public_agent>",
     clientTools = mapOf(
         "logMessage" to object : io.elevenlabs.ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult? {
                 val message = parameters["message"] as? String ?: return io.elevenlabs.ClientToolResult.failure("Missing 'message'")
                 android.util.Log.d("ClientTool", "Log: $message")
-                return io.elevenlabs.ClientToolResult.success("ok")
+                return null // No response needed for fire-and-forget tools
             }
         }
     )

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientTool.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientTool.kt
@@ -11,9 +11,9 @@ interface ClientTool {
      * Execute the tool with the provided parameters
      *
      * @param parameters Map of parameter names to values provided by the agent
-     * @return Result of the tool execution
+     * @return Result of the tool execution, or null if no response should be sent
      */
-    suspend fun execute(parameters: Map<String, Any>): ClientToolResult
+    suspend fun execute(parameters: Map<String, Any>): ClientToolResult?
 }
 
 /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientToolRegistry.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientToolRegistry.kt
@@ -65,7 +65,7 @@ class ClientToolRegistry {
         name: String,
         parameters: Map<String, Any>,
         timeoutMs: Long = DEFAULT_TIMEOUT_MS
-    ): ClientToolResult {
+    ): ClientToolResult? {
         val tool = tools[name]
             ?: return ClientToolResult.failure("Tool '$name' not found")
 
@@ -91,7 +91,7 @@ class ClientToolRegistry {
     fun executeToolAsync(
         name: String,
         parameters: Map<String, Any>,
-        callback: ((ClientToolResult) -> Unit)? = null
+        callback: ((ClientToolResult?) -> Unit)? = null
     ) {
         scope.launch {
             val result = executeTool(name, parameters)
@@ -203,7 +203,7 @@ class ClientToolRegistryBuilder {
      */
     fun addTool(name: String, function: suspend (Map<String, Any>) -> String): ClientToolRegistryBuilder {
         registry.registerTool(name, object : ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
                 return try {
                     val result = function(parameters)
                     ClientToolResult.success(result)
@@ -232,7 +232,7 @@ object CommonClientTools {
      * Tool for getting the current time
      */
     val getCurrentTime = object : ClientTool {
-        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
             val format = parameters["format"] as? String ?: "yyyy-MM-dd HH:mm:ss"
             return try {
                 val currentTime = java.text.SimpleDateFormat(format, Locale.US).format(java.util.Date())
@@ -247,7 +247,7 @@ object CommonClientTools {
      * Tool for getting device information
      */
     val getDeviceInfo = object : ClientTool {
-        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
             return try {
                 val deviceInfo = """
                     Device: ${android.os.Build.DEVICE}
@@ -267,7 +267,7 @@ object CommonClientTools {
      * Tool for logging messages
      */
     val logMessage = object : ClientTool {
-        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
             val message = parameters["message"] as? String
                 ?: return ClientToolResult.failure("Missing 'message' parameter")
             val level = parameters["level"] as? String ?: "INFO"

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
@@ -148,7 +148,7 @@ class ConversationSessionBuilder(private val context: Context) {
      */
     fun addTool(name: String, function: suspend (Map<String, Any>) -> String): ConversationSessionBuilder {
         customTools[name] = object : ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
                 return try {
                     val result = function(parameters)
                     ClientToolResult.success(result)

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -134,8 +134,8 @@ class ConversationEventHandler(
                 ClientToolResult.failure("Tool execution failed: ${e.message}")
             }
 
-            // Send result back to agent if response is expected
-            if (event.expectsResponse) {
+            // Send result back to agent if response is expected and result is not null
+            if (event.expectsResponse && result != null) {
                 val toolResultEvent = OutgoingEvent.ClientToolResult(
                     toolCallId = event.toolCallId,
                     result = mapOf<String, Any>(
@@ -148,7 +148,7 @@ class ConversationEventHandler(
 
                 messageCallback(toolResultEvent)
             }
-            Log.d("ConvEventHandler", "Tool executed: ${event.toolName} -> ${if (result.success) "SUCCESS" else "FAILED"}")
+            Log.d("ConvEventHandler", "Tool executed: ${event.toolName} -> ${if (result == null) "NO_RESPONSE" else if (result.success) "SUCCESS" else "FAILED"}")
         }
     }
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
@@ -73,7 +73,7 @@ sealed class ConversationEvent {
         val toolName: String,
         val parameters: Map<String, Any>,
         val toolCallId: String,
-        val expectsResponse: Boolean = true,
+        val expectsResponse: Boolean = false,
     ) : ConversationEvent()
 
     /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
@@ -130,7 +130,7 @@ object ConversationEventParser {
             toolName = obj.get("tool_name")?.asString ?: "",
             parameters = parameters,
             toolCallId = obj.get("tool_call_id")?.asString ?: "",
-            expectsResponse = obj.get("expects_response")?.asBoolean ?: true,
+            expectsResponse = obj.get("expects_response")?.asBoolean == true,
         )
     }
 

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationSessionBuilderTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationSessionBuilderTest.kt
@@ -144,7 +144,8 @@ class ConversationSessionBuilderTest {
         // Test the captured tool
         assertNotNull(capturedTool)
         val result = capturedTool!!.execute(mapOf("input" to "test"))
-        assertTrue(result.success)
+        assertNotNull(result)
+        assertTrue(result!!.success)
         assertEquals("result: test", result.result)
     }
 
@@ -170,7 +171,8 @@ class ConversationSessionBuilderTest {
         // Test the captured tool
         assertNotNull(capturedTool)
         val result = capturedTool!!.execute(emptyMap())
-        assertFalse(result.success)
+        assertNotNull(result)
+        assertFalse(result!!.success)
         assertEquals("Function execution failed: Test exception", result.error)
     }
 

--- a/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
@@ -73,7 +73,7 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                     dynamicVariables = null,
                     clientTools = mapOf(
                         "logMessage" to object : io.elevenlabs.ClientTool {
-                            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult {
+                            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult? {
                                 val message = parameters["message"] as? String
                                     ?: return io.elevenlabs.ClientToolResult.failure("Missing 'message' parameter")
                                 val level = parameters["level"] as? String ?: "INFO"


### PR DESCRIPTION
# Problem

The SDK previously assumed all client tools would send a response back to the agent. However, some server-side tools are configured with `expects_response=false`, meaning they don't expect or wait for a client response. When the Android SDK always sent responses for these tools, it could cause unexpected behavior or errors on the server side. See [issue](https://github.com/elevenlabs/elevenlabs-android/issues/4)

# Solution

This PR modifies the client tool execution mechanism to support optional responses:

# Key Changes

1. Made `ClientTool.execute()` return nullable `ClientToolResult?`

   * Tools can now return `null` to indicate no response should be sent to the agent
   * Maintains backward compatibility for tools that always return a result

2. Updated event handler logic

   * Only sends `client_tool_result` events when both:

     * The server expects a response (`expectsResponse == true`)
     * The tool returns a non-null result
   * Logs appropriate status: `"NO_RESPONSE"`, `"SUCCESS"`, or `"FAILED"`

3. Fixed default behavior

   * Changed default value of `expectsResponse` from `true` to `false` to match server behavior
   * Parser explicitly checks for `expects_response` field in incoming events

4. Updated all implementations

   * Modified all built-in tools and examples to use the new nullable return type
   * Updated tests to handle nullable results appropriately
   * Added documentation explaining when to return `null`

# Usage Example

```kotlin
// Fire-and-forget tool that doesn't send a response
clientTools = mapOf(
    "logMessage" to object : ClientTool {
        override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
            Log.d("App", parameters["message"] as String)
            return null  // No response needed
        }
    }
)
```

# Testing

* Tested with server-side tools configured with both `expects_response=true` and `expects_response=false`

# Breaking Changes

The change is backward compatible. Tools that always return a result will continue to work.