### PR TITLE
Add .mailmap to correct co-author email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+bonsainoodle <3sprix.exe@gmail.com> <bonsainoodle@github.com>


### PR DESCRIPTION
Adds a `.mailmap` file to correct the email attribution for @bonsainoodle from
  `bonsainoodle@github.com` to `3sprix.exe@gmail.com`.

  ### Changes
  - Added `.mailmap` file to map the incorrect email to the correct one

  ### Context
  As discussed in #7, a co-author's email was incorrectly set to `bonsainoodle@github.com` in a
  previous merged commit. This PR adds a mailmap file to ensure proper attribution without
  rewriting commit history.

  Fixes #7