### PR TITLE
Expose api and websocket URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ val config = ConversationConfig(
     agentId = "<your_public_agent_id>", // OR conversationToken = "<token>"
     userId = "your-user-id",
     audioInputSampleRate = "48000", // Optional parameter, defaults to 48kHz. Lower values can help with audio input issues on slower connections
+    apiEndpoint = "https://api.elevenlabs.io", // Optional: Custom API endpoint
+    websocketUrl = "wss://livekit.rtc.elevenlabs.io", // Optional: Custom WebSocket URL
     // Optional callbacks
     onConnect = { conversationId ->
         // Connected, you can store conversationId via session.getId() too
@@ -145,6 +147,29 @@ session.endSession()
 
 - **Public agents** (no auth): Initialize with `agentId` in `ConversationConfig`. The SDK requests a conversation token from ElevenLabs without needing an API key on device.
 - **Private agents** (auth): Initialize with `conversationToken` in `ConversationConfig`. Issued by your server (your backend uses the ElevenLabs API key). **Never embed API keys in clients.**
+
+---
+
+## Advanced Configuration
+
+### Custom Endpoints
+
+For self-hosted or custom deployments, you can configure custom endpoints:
+
+```kotlin
+val config = ConversationConfig(
+    agentId = "<your_agent_id>",
+    apiEndpoint = "https://custom-api.example.com",      // Custom API endpoint (default: "https://api.elevenlabs.io")
+    websocketUrl = "wss://custom-webrtc.example.com"     // Custom WebSocket URL (default: "wss://livekit.rtc.elevenlabs.io")
+)
+```
+
+- **apiEndpoint**: Base URL for the ElevenLabs API. Used for fetching conversation tokens when using public agents.
+- **websocketUrl**: WebSocket URL for the LiveKit WebRTC connection. Used for the real-time audio/data channel connection.
+
+Both parameters are optional and default to the standard ElevenLabs production endpoints.
+
+**Note**: If you are using [data residency](https://elevenlabs.io/docs/product-guides/administration/data-residency), make sure that both `apiEndpoint` and `websocketUrl` point to the same geographic region. For example `https://api.eu.residency.elevenlabs.io` and `wss://livekit.rtc.eu.residency.elevenlabs.io` respectively. A mismatch will result in errors when authenticating.
 
 ---
 

--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.elevenlabs"
-version = "0.2.0"
+version = "0.3.0"
 
 android {
 namespace = "io.elevenlabs"

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
@@ -38,7 +38,7 @@ internal object ConversationClientImpl {
 
         // Generate token if needed for public agents
         val finalConfig = if (!config.isPrivateAgent) {
-            val tokenService = TokenService()
+            val tokenService = TokenService(baseUrl = config.apiEndpoint)
             val tokenResponse = tokenService.fetchPublicAgentToken(
                 config.agentId!!,
                 config.overrides?.client?.source ?: "android_sdk",

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
@@ -22,6 +22,8 @@ import io.elevenlabs.models.ConversationEvent.ClientToolCall
  * @param userId Optional user identifier for conversation tracking
  * @param textOnly Whether to use text-only mode (true) or voice mode (false, default)
  * @param audioInputSampleRate Sample rate for audio recording in Hz (default: 48000 for high quality)
+ * @param apiEndpoint Base URL for ElevenLabs API (default: "https://api.elevenlabs.io")
+ * @param websocketUrl WebSocket URL for LiveKit WebRTC connection (default: "wss://livekit.rtc.elevenlabs.io")
  */
 data class ConversationConfig(
     val agentId: String? = null,
@@ -29,6 +31,8 @@ data class ConversationConfig(
     val userId: String? = null,
     val textOnly: Boolean = false,
     val audioInputSampleRate: Int = 48000,
+    val apiEndpoint: String = "https://api.elevenlabs.io",
+    val websocketUrl: String = "wss://livekit.rtc.elevenlabs.io",
     val overrides: Overrides? = null,
     val customLlmExtraBody: Map<String, Any>? = null,
     val dynamicVariables: Map<String, Any>? = null,

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
@@ -85,7 +85,7 @@ internal class ConversationSessionImpl(
             }
 
             // Start the connection
-            val serverUrl = "wss://livekit.rtc.elevenlabs.io" // Default URL, can be configured
+            val serverUrl = config.websocketUrl
             val token = config.conversationToken ?: ""
             Log.d("ConversationSession", "Starting connection to $serverUrl")
             // Wrap onConnect to capture conversationId while preserving user's callback


### PR DESCRIPTION
Expose URLs so users can configure data residency. 