### PR TITLE
fix: change client_tool_result.result from Map to String

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,33 +280,19 @@ val config = ConversationConfig(
         // Handle dynamic tool execution
         when (toolCall.toolName) {
             "getDeviceInfo" -> {
-                val result = mapOf(
-                    "success" to true,
-                    "result" to "Device: ${Build.MODEL}",
-                    "error" to ""
-                )
-                session.sendToolResult(toolCall.toolCallId, result, isError = false)
+                // Send result as a string
+                session.sendToolResult(toolCall.toolCallId, "Device: ${Build.MODEL}", isError = false)
             }
             "fetchUserData" -> {
                 // Perform async operation
                 coroutineScope.launch {
                     val data = fetchDataFromAPI(toolCall.parameters)
-                    val result = mapOf(
-                        "success" to true,
-                        "result" to data,
-                        "error" to ""
-                    )
-                    session.sendToolResult(toolCall.toolCallId, result, isError = false)
+                    session.sendToolResult(toolCall.toolCallId, data, isError = false)
                 }
             }
             else -> {
-                // Unknown tool
-                val errorResult = mapOf(
-                    "success" to false,
-                    "result" to "",
-                    "error" to "Unknown tool: ${toolCall.toolName}"
-                )
-                session.sendToolResult(toolCall.toolCallId, errorResult, isError = true)
+                // Unknown tool - send error
+                session.sendToolResult(toolCall.toolCallId, "Unknown tool: ${toolCall.toolName}", isError = true)
             }
         }
     }
@@ -314,7 +300,7 @@ val config = ConversationConfig(
 ```
 
 **Key methods:**
-- `session.sendToolResult(toolCallId, result, isError)`: Send tool execution results back to the agent manually. Use this in the `onUnhandledClientToolCall` callback to respond to dynamic tool calls.
+- `session.sendToolResult(toolCallId, result, isError)`: Send tool execution results back to the agent manually. The `result` parameter is a string (use JSON string for complex data). Use this in the `onUnhandledClientToolCall` callback to respond to dynamic tool calls.
 - `toolCall.expectsResponse`: Check this property to determine if the agent expects a response. If `false`, the tool is fire-and-forget and you can skip calling `sendToolResult()`.
 
 This approach is useful for:

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSession.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSession.kt
@@ -95,10 +95,10 @@ interface ConversationSession {
      * execute your tool and then send the result back using this method.
      *
      * @param toolCallId The unique identifier for the tool call (from ClientToolCall event)
-     * @param result Map containing the result data
+     * @param result The result string to send back to the agent
      * @param isError Whether the tool execution resulted in an error
      */
-    fun sendToolResult(toolCallId: String, result: Map<String, Any>, isError: Boolean = false)
+    fun sendToolResult(toolCallId: String, result: String, isError: Boolean = false)
 
     // Audio Control Methods
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
@@ -203,7 +203,7 @@ internal class ConversationSessionImpl(
         eventHandler.sendUserActivity()
     }
 
-    override fun sendToolResult(toolCallId: String, result: Map<String, Any>, isError: Boolean) {
+    override fun sendToolResult(toolCallId: String, result: String, isError: Boolean) {
         eventHandler.sendToolResult(toolCallId, result, isError)
     }
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
@@ -363,11 +363,13 @@ sealed class OutgoingEvent {
 
     /**
      * Tool result event
+     * Note: result must be a String (plain text or JSON string), not a Map/Object.
+     * The backend expects result as a string field.
      */
     data class ClientToolResult(
         @SerializedName("tool_call_id")
         val toolCallId: String,
-        val result: Map<String, Any>,
+        val result: String,
         @SerializedName("is_error")
         val isError: Boolean = false,
     ) : OutgoingEvent() {

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/DynamicClientToolTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/DynamicClientToolTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.*
  * This test suite verifies:
  * 1. sendToolResult() method correctly sends tool results
  * 2. Tool result event structure and serialization
- * 3. Support for complex nested result structures
+ * 3. Support for string result values
  */
 class DynamicClientToolTest {
 
@@ -47,10 +47,7 @@ class DynamicClientToolTest {
             messageCallback = messageCallback
         )
 
-        val result = mapOf(
-            "data" to "test data",
-            "count" to 42
-        )
+        val result = "The temperature is 25 degrees"
 
         eventHandler.sendToolResult(
             toolCallId = "tool-123",
@@ -73,9 +70,7 @@ class DynamicClientToolTest {
             messageCallback = messageCallback
         )
 
-        val errorResult = mapOf(
-            "error" to "Something went wrong"
-        )
+        val errorResult = "Something went wrong"
 
         eventHandler.sendToolResult(
             toolCallId = "tool-456",
@@ -91,38 +86,26 @@ class DynamicClientToolTest {
     }
 
     @Test
-    fun `sendToolResult with complex nested result structure`() {
+    fun `sendToolResult with JSON string result`() {
         val eventHandler = ConversationEventHandler(
             audioManager = audioManager,
             toolRegistry = toolRegistry,
             messageCallback = messageCallback
         )
 
-        val complexResult = mapOf(
-            "status" to "completed",
-            "data" to mapOf(
-                "items" to listOf(
-                    mapOf("id" to 1, "name" to "Item 1"),
-                    mapOf("id" to 2, "name" to "Item 2")
-                ),
-                "count" to 2
-            ),
-            "metadata" to mapOf(
-                "timestamp" to 1234567890,
-                "version" to "1.0.0"
-            )
-        )
+        // When you need to send complex data, serialize it as a JSON string
+        val jsonResult = """{"status":"completed","items":[{"id":1,"name":"Item 1"},{"id":2,"name":"Item 2"}],"count":2}"""
 
         eventHandler.sendToolResult(
             toolCallId = "complex-789",
-            result = complexResult,
+            result = jsonResult,
             isError = false
         )
 
         assertEquals(1, capturedEvents.size)
         val event = capturedEvents[0] as OutgoingEvent.ClientToolResult
         assertEquals("complex-789", event.toolCallId)
-        assertEquals(complexResult, event.result)
+        assertEquals(jsonResult, event.result)
         assertFalse(event.isError)
     }
 }


### PR DESCRIPTION
The backend expects client_tool_result.result as a string, not a JSON object. This was causing 'policy violation' errors when client tools returned results.

Changes:
- ConversationEventParser.kt: Change ClientToolResult.result type from Map<String, Any> to String
- ConversationEventHandler.kt: Send result as string directly, not wrapped in a map
- ConversationSession.kt: Update interface signature for sendToolResult()
- ConversationSessionImpl.kt: Update implementation signature
- DynamicClientToolTest.kt: Update tests to use string results
- README.md: Update documentation examples

Note: Users can still send complex data by serializing to JSON string (e.g., Gson().toJson(myObject)).