### PR TITLE
Add environment parameter support

### DIFF
--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
@@ -42,7 +42,8 @@ internal object ConversationClientImpl {
             val tokenResponse = tokenService.fetchPublicAgentToken(
                 config.agentId!!,
                 config.overrides?.client?.source ?: "android_sdk",
-                config.overrides?.client?.version ?: BuildConfig.SDK_VERSION
+                config.overrides?.client?.version ?: BuildConfig.SDK_VERSION,
+                config.environment
             )
             config.copy(conversationToken = tokenResponse.token, agentId = null)
         } else {

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
@@ -27,6 +27,7 @@ import io.elevenlabs.models.DisconnectionDetails
  * @param audioInputSampleRate Sample rate for audio recording in Hz (default: 48000 for high quality)
  * @param apiEndpoint Base URL for ElevenLabs API (default: "https://api.elevenlabs.io")
  * @param websocketUrl WebSocket URL for LiveKit WebRTC connection (default: "wss://livekit.rtc.elevenlabs.io")
+ * @param environment Optional environment name for the agent (defaults to "production" on the server)
  */
 data class ConversationConfig(
     val agentId: String? = null,
@@ -36,6 +37,7 @@ data class ConversationConfig(
     val audioInputSampleRate: Int = 48000,
     val apiEndpoint: String = "https://api.elevenlabs.io",
     val websocketUrl: String = "wss://livekit.rtc.elevenlabs.io",
+    val environment: String? = null,
     val overrides: Overrides? = null,
     val customLlmExtraBody: Map<String, Any>? = null,
     val dynamicVariables: Map<String, Any>? = null,

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/TokenService.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/TokenService.kt
@@ -27,11 +27,12 @@ class TokenService(
      * @param agentId The ID of the public agent to get a token for
      * @param source Optional source identifier (defaults to "android_sdk")
      * @param version Optional version string (defaults to SDK version)
+     * @param environment Optional environment name (defaults to "production" on the server)
      * @return TokenResponse containing the token and connection details
      * @throws TokenServiceException if the request fails or returns an error
      */
-    suspend fun fetchPublicAgentToken(agentId: String, source: String, version: String): TokenResponse = withContext(Dispatchers.IO) {
-        val url = buildTokenUrl(agentId, source, version)
+    suspend fun fetchPublicAgentToken(agentId: String, source: String, version: String, environment: String? = null): TokenResponse = withContext(Dispatchers.IO) {
+        val url = buildTokenUrl(agentId, source, version, environment)
 
         val request = Request.Builder()
             .url(url)
@@ -66,13 +67,60 @@ class TokenService(
     }
 
     /**
+     * Fetch a signed URL for a conversation (no API key required)
+     *
+     * @param agentId The ID of the agent to get a signed URL for
+     * @param environment Optional environment name (defaults to "production" on the server)
+     * @return SignedUrlResponse containing the signed URL
+     * @throws TokenServiceException if the request fails or returns an error
+     */
+    suspend fun fetchSignedUrl(agentId: String, environment: String? = null): SignedUrlResponse = withContext(Dispatchers.IO) {
+        var url = "$baseUrl/v1/convai/conversation/get_signed_url?agent_id=$agentId"
+        environment?.let { url += "&environment=$it" }
+
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Accept", "application/json")
+            .get()
+            .build()
+
+        try {
+            val response = httpClient.newCall(request).execute()
+
+            if (!response.isSuccessful) {
+                val errorBody = response.body?.string() ?: "Unknown error"
+                throw TokenServiceException(
+                    "Failed to fetch signed URL: HTTP ${response.code} - $errorBody"
+                )
+            }
+
+            val responseBody = response.body?.string()
+                ?: throw TokenServiceException("Empty response body")
+
+            try {
+                val parsed = gson.fromJson(responseBody, SignedUrlResponse::class.java)
+                    ?: throw TokenServiceException("Failed to parse signed URL response")
+                parsed
+            } catch (e: Exception) {
+                throw TokenServiceException("Failed to parse signed URL response: ${e.message}", e)
+            }
+
+        } catch (e: IOException) {
+            throw TokenServiceException("Network error: ${e.message}", e)
+        }
+    }
+
+    /**
      * Build the URL for fetching conversation tokens
      *
      * @param agentId The agent ID to include in the request
+     * @param environment Optional environment name
      * @return Complete URL for the token request
      */
-    private fun buildTokenUrl(agentId: String, source: String, version: String): String {
-        return "$baseUrl/v1/convai/conversation/token?agent_id=$agentId&source=$source&version=$version"
+    private fun buildTokenUrl(agentId: String, source: String, version: String, environment: String? = null): String {
+        var url = "$baseUrl/v1/convai/conversation/token?agent_id=$agentId&source=$source&version=$version"
+        environment?.let { url += "&environment=$it" }
+        return url
     }
 }
 
@@ -84,6 +132,16 @@ class TokenService(
 data class TokenResponse(
     @SerializedName("token")
     val token: String,
+)
+
+/**
+ * Response from the ElevenLabs signed URL API
+ *
+ * @param signedUrl The signed URL to use for connecting
+ */
+data class SignedUrlResponse(
+    @SerializedName("signed_url")
+    val signedUrl: String,
 )
 
 /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/TokenService.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/TokenService.kt
@@ -67,50 +67,6 @@ class TokenService(
     }
 
     /**
-     * Fetch a signed URL for a conversation (no API key required)
-     *
-     * @param agentId The ID of the agent to get a signed URL for
-     * @param environment Optional environment name (defaults to "production" on the server)
-     * @return SignedUrlResponse containing the signed URL
-     * @throws TokenServiceException if the request fails or returns an error
-     */
-    suspend fun fetchSignedUrl(agentId: String, environment: String? = null): SignedUrlResponse = withContext(Dispatchers.IO) {
-        var url = "$baseUrl/v1/convai/conversation/get_signed_url?agent_id=$agentId"
-        environment?.let { url += "&environment=$it" }
-
-        val request = Request.Builder()
-            .url(url)
-            .addHeader("Accept", "application/json")
-            .get()
-            .build()
-
-        try {
-            val response = httpClient.newCall(request).execute()
-
-            if (!response.isSuccessful) {
-                val errorBody = response.body?.string() ?: "Unknown error"
-                throw TokenServiceException(
-                    "Failed to fetch signed URL: HTTP ${response.code} - $errorBody"
-                )
-            }
-
-            val responseBody = response.body?.string()
-                ?: throw TokenServiceException("Empty response body")
-
-            try {
-                val parsed = gson.fromJson(responseBody, SignedUrlResponse::class.java)
-                    ?: throw TokenServiceException("Failed to parse signed URL response")
-                parsed
-            } catch (e: Exception) {
-                throw TokenServiceException("Failed to parse signed URL response: ${e.message}", e)
-            }
-
-        } catch (e: IOException) {
-            throw TokenServiceException("Network error: ${e.message}", e)
-        }
-    }
-
-    /**
      * Build the URL for fetching conversation tokens
      *
      * @param agentId The agent ID to include in the request
@@ -132,16 +88,6 @@ class TokenService(
 data class TokenResponse(
     @SerializedName("token")
     val token: String,
-)
-
-/**
- * Response from the ElevenLabs signed URL API
- *
- * @param signedUrl The signed URL to use for connecting
- */
-data class SignedUrlResponse(
-    @SerializedName("signed_url")
-    val signedUrl: String,
 )
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `environment` parameter to `ConversationConfig` (defaults to `null`, server defaults to `"production"`)
- Pass `environment` as a query parameter to the `GET /v1/convai/conversation/token` endpoint
- Add `fetchSignedUrl()` method to `TokenService` with `environment` support for `GET /v1/convai/conversation/get_signed_url`
- Add `SignedUrlResponse` data class

## Test plan
- [ ] Verify existing tests pass (no breaking changes — `environment` defaults to `null` everywhere)
- [ ] Test public agent token fetch with `environment` set (e.g. `"staging"`)
- [ ] Test public agent token fetch without `environment` (default behavior unchanged)
- [ ] Test `fetchSignedUrl` with and without `environment` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)