### PR TITLE
ConversationConfig: add media audio stream option

### DIFF
--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
@@ -15,6 +15,7 @@ import io.elevenlabs.ConversationConfig
 import io.livekit.android.LiveKit
 import io.livekit.android.LiveKitOverrides
 import io.livekit.android.AudioOptions
+import io.livekit.android.AudioType
 import io.livekit.android.audio.AudioProcessorOptions
 
 /**
@@ -81,6 +82,11 @@ internal object ConversationClientImpl {
             appContext = context,
             overrides = LiveKitOverrides(
                 audioOptions = AudioOptions(
+                    audioOutputType = if (finalConfig.useMediaStream) {
+                        AudioType.MediaAudioType()
+                    } else {
+                        AudioType.CallAudioType()
+                    },
                     javaAudioDeviceModuleCustomizer = { builder ->
                         builder.setSampleRate(finalConfig.audioInputSampleRate)
                     },

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
@@ -86,6 +86,7 @@ data class ConversationConfig(
     val onDisconnect: ((details: DisconnectionDetails) -> Unit)? = null,
     val onError: ((code: Int, message: String?) -> Unit)? = null,
     val audioConfiguration: AudioPipelineConfiguration? = null,
+    val useMediaStream: Boolean = false
 ) {
     init {
         agentId?.let { require(it.isNotBlank()) { "agentId cannot be blank" } }


### PR DESCRIPTION
Our use case for this feature: we have an app that uses the ElevenLabs SDK that we use with various robots. Sometimes we run the app on the robot itself (if it's an Android based robot like a temi). Other times, we just stick a tablet on a robot's chassis. In the former case, sometimes the call volume isn't able to be adjusted on these robots; only the media volume. In the latter case, the tablets' internal speakers are not very loud (not good for crowded events), so we must use an external speaker - however, the call stream doesn't always output to the connected speaker (presumably because of a lack of mic), and insists on using the quiet internal speaker.

Having the ability to select the media stream in the conversation config addresses both of these problems :blush:.