### PR TITLE
expose reconciled message transcript as StateFlow

### DIFF
--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -412,19 +412,16 @@ class ConversationEventHandler(
 
     // region Transcript reconciliation
     //
-    // Each transcript/response is reconciled against the tail of its role's messages by event id,
-    // so [messages] stays consistent for any input order:
-    //   - a newer event id than the role's last message starts a new message;
-    //   - a matching event id updates the existing message (per the rules below);
-    //   - an older, unmatched event id is ignored.
-    // Messages are only ever appended (never reordered), so the absolute order follows the arrival
-    // of finalized text, and per-role event ids stay ordered and unique. A missing ([null]) event
-    // id can't be ordered, so it's treated as belonging to a new message.
+    // Each transcript/response is matched against its role's messages by event id, so [messages] is
+    // consistent for any arrival order: a newer id appends a new message, a matching id updates the
+    // existing one, an older unmatched id is ignored. Messages are only appended (never reordered),
+    // so per-role event ids stay ordered and unique. A null event id can't be ordered and starts a
+    // new message.
 
     /**
-     * Streaming `agent_chat_response_part`: accumulates streamed text. A matching message is grown
-     * in place while still partial and finalized on [isStop]; a finalized message is never reopened.
-     * With no match, a part for a newer turn starts a fresh message and a stale one is ignored.
+     * Streaming `agent_chat_response_part`: appends text to the matching partial and finalizes it on
+     * [isStop]; a finalized message is never reopened. With no match, a newer turn starts a new
+     * message and a stale part is ignored.
      */
     private fun appendAgentResponsePart(text: String, eventId: Int?, isStop: Boolean) {
         _messages.update { current ->
@@ -446,8 +443,8 @@ class ConversationEventHandler(
 
     /**
      * `agent_response` / `agent_response_correction`: the canonical finalized response for a turn.
-     * Updates the matching message in place (even after it was finalized), appends when it belongs
-     * to a newer turn, and ignores a stale/unmatched event id.
+     * Overwrites the matching message in place (even if already finalized), appends for a newer turn,
+     * ignores a stale/unmatched event id.
      */
     private fun applyAgentResponse(content: String, eventId: Int?) {
         _messages.update { current ->
@@ -464,9 +461,8 @@ class ConversationEventHandler(
     }
 
     /**
-     * Finalized `user_transcript`: finalizes the matching in-progress partial, or appends when it
-     * belongs to a newer turn; then drops any leftover partial (a tentative that never produced its
-     * own final), so a final never leaves a stray partial bubble behind.
+     * Finalized `user_transcript`: finalizes the matching partial or appends for a newer turn, then
+     * drops any leftover user partial so a final never leaves a stray partial bubble behind.
      */
     private fun applyUserTranscript(content: String, eventId: Int?) {
         _messages.update { current ->
@@ -484,8 +480,8 @@ class ConversationEventHandler(
     }
 
     /**
-     * `tentative_user_transcript`: the in-progress user transcript. Supersedes any existing partial,
-     * then surfaces a fresh one if it belongs to a turn newer than the last finalized transcript.
+     * `tentative_user_transcript`: the in-progress user transcript. Replaces any existing partial,
+     * then re-adds it only if newer than the last finalized transcript.
      */
     private fun applyTentativeUserTranscript(content: String, eventId: Int?) {
         _messages.update { current ->
@@ -498,21 +494,37 @@ class ConversationEventHandler(
         }
     }
 
-    /** Index of the message for [role] carrying exactly [eventId], or null (never matches null ids). */
+    /**
+     * Index of [role]'s message with exactly [eventId], or null (null ids never match).
+     *
+     * Scans from the tail and stops at the first same-role id below [eventId]: a role's ids rise with
+     * position, so the target can't be further back. This keeps the hot paths O(1) — updating the
+     * latest message or appending a newer one. Null-id local messages (typed sends) carry no order
+     * and are skipped.
+     */
     private fun List<Message>.messageIndex(role: MessageRole, eventId: Int?): Int? {
         if (eventId == null) return null
-        val idx = indexOfFirst { it.role == role && it.eventId == eventId }
-        return if (idx >= 0) idx else null
+        for (i in lastIndex downTo 0) {
+            val candidate = this[i]
+            if (candidate.role != role) continue
+            val candidateId = candidate.eventId ?: continue
+            when {
+                candidateId == eventId -> return i
+                candidateId < eventId -> return null // ids rise with position; target is absent
+            }
+        }
+        return null
     }
 
     /**
-     * Whether [eventId] is newer than [role]'s most recent message. Messages are appended in arrival
-     * order, so the last message of a role carries its highest event id. A null incoming id (or a
-     * role whose last message has no id) can't be ordered and is treated as newer.
+     * Whether [eventId] is newer than [role]'s latest server-assigned message. The last id-carrying
+     * message of a role holds its highest event id. Null-id local messages (typed sends) are skipped
+     * so they can't make a stale transcript look newer. A null incoming id (or no id-carrying
+     * message) can't be ordered and is treated as newer.
      */
     private fun List<Message>.isNewerThanLastMessage(role: MessageRole, eventId: Int?): Boolean {
         if (eventId == null) return true
-        val lastEventId = lastOrNull { it.role == role }?.eventId ?: return true
+        val lastEventId = lastOrNull { it.role == role && it.eventId != null }?.eventId ?: return true
         return eventId > lastEventId
     }
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -7,6 +7,7 @@ import io.elevenlabs.network.OutgoingEvent
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * Event processing pipeline for real-time conversation
@@ -39,8 +40,9 @@ class ConversationEventHandler(
     private val _conversationMode = MutableStateFlow(ConversationMode.LISTENING)
     val conversationMode: StateFlow<ConversationMode> = _conversationMode
 
-    // Keep track of the last agent event ID for feedback
-    private var _lastAgentEventId: Int? = null
+    // Reconciled conversation transcript exposed by the session.
+    private val _messages = MutableStateFlow<List<Message>>(emptyList())
+    val messages: StateFlow<List<Message>> = _messages
 
     // Keep track of the last event ID we sent feedback for to prevent duplicates
     private var _lastFeedbackSentForEventIdInt: Int? = null
@@ -81,6 +83,8 @@ class ConversationEventHandler(
      * Handle streaming agent chat response parts
      */
     private suspend fun handleAgentChatResponsePart(event: ConversationEvent.AgentChatResponsePart) {
+        appendAgentResponsePart(text = event.text, eventId = event.eventId, isStop = event.partType == "stop")
+
         when (event.partType) {
             "start" -> {
                 _conversationMode.value = ConversationMode.SPEAKING
@@ -103,6 +107,7 @@ class ConversationEventHandler(
      * Handle tentative user transcripts (partial recognition)
      */
     private suspend fun handleTentativeUserTranscript(event: ConversationEvent.TentativeUserTranscript) {
+        applyTentativeUserTranscript(content = event.userTranscript, eventId = event.eventId)
         try { onUserTranscript?.invoke(event.userTranscript) } catch (_: Throwable) {}
     }
 
@@ -131,6 +136,8 @@ class ConversationEventHandler(
      * Handle agent response events
      */
     private suspend fun handleAgentResponse(event: ConversationEvent.AgentResponse) {
+        applyAgentResponse(content = event.agentResponse, eventId = event.eventId)
+
         // Update conversation mode to speaking
         _conversationMode.value = ConversationMode.SPEAKING
 
@@ -146,7 +153,6 @@ class ConversationEventHandler(
             }
         }
 
-
         try {
             onAgentResponse?.invoke(event.agentResponse)
         } catch (e: Exception) {
@@ -158,6 +164,7 @@ class ConversationEventHandler(
      * Handle user transcript events
      */
     private suspend fun handleUserTranscript(event: ConversationEvent.UserTranscript) {
+        applyUserTranscript(content = event.userTranscript, eventId = event.eventId)
         try {
             onUserTranscript?.invoke(event.userTranscript)
         } catch (e: Exception) {
@@ -166,6 +173,7 @@ class ConversationEventHandler(
     }
 
     private fun handleAgentResponseCorrection(event: ConversationEvent.AgentResponseCorrection) {
+        applyAgentResponse(content = event.correctedAgentResponse, eventId = event.eventId)
         try {
             onAgentResponseCorrection?.invoke(event.originalAgentResponse, event.correctedAgentResponse)
         } catch (e: Exception) {
@@ -316,6 +324,7 @@ class ConversationEventHandler(
     fun sendUserMessage(content: String) {
         val event = OutgoingEvent.UserMessage(text = content)
         messageCallback(event)
+        appendLocalMessage(role = MessageRole.USER, content = content)
     }
 
     /**
@@ -341,7 +350,9 @@ class ConversationEventHandler(
      * @param isPositive true for positive feedback, false for negative
      */
     fun sendFeedback(isPositive: Boolean) {
-        val lastEventId = _lastAgentEventId
+        // The latest agent reply is the last agent message in arrival order; its event id is the
+        // feedback target.
+        val lastEventId = _messages.value.lastOrNull { it.role == MessageRole.AGENT }?.eventId
         val lastFeedbackSentForEventId = _lastFeedbackSentForEventIdInt
 
         if (lastEventId != null) {
@@ -399,14 +410,123 @@ class ConversationEventHandler(
      */
     fun getCurrentMode(): ConversationMode = _conversationMode.value
 
-    // No message list getter; UI should use server transcripts
+    // region Transcript reconciliation
+    //
+    // Each transcript/response is reconciled against the tail of its role's messages by event id,
+    // so [messages] stays consistent for any input order:
+    //   - a newer event id than the role's last message starts a new message;
+    //   - a matching event id updates the existing message (per the rules below);
+    //   - an older, unmatched event id is ignored.
+    // Messages are only ever appended (never reordered), so the absolute order follows the arrival
+    // of finalized text, and per-role event ids stay ordered and unique. A missing ([null]) event
+    // id can't be ordered, so it's treated as belonging to a new message.
+
+    /**
+     * Streaming `agent_chat_response_part`: accumulates streamed text. A matching message is grown
+     * in place while still partial and finalized on [isStop]; a finalized message is never reopened.
+     * With no match, a part for a newer turn starts a fresh message and a stale one is ignored.
+     */
+    private fun appendAgentResponsePart(text: String, eventId: Int?, isStop: Boolean) {
+        _messages.update { current ->
+            val idx = current.messageIndex(MessageRole.AGENT, eventId)
+            when {
+                idx != null -> {
+                    val existing = current[idx]
+                    if (!existing.isPartial) current
+                    else current.toMutableList().also {
+                        it[idx] = existing.copy(content = existing.content + text, eventId = eventId, isPartial = !isStop)
+                    }
+                }
+                current.isNewerThanLastMessage(MessageRole.AGENT, eventId) ->
+                    current + Message(role = MessageRole.AGENT, content = text, eventId = eventId, isPartial = !isStop)
+                else -> current
+            }
+        }
+    }
+
+    /**
+     * `agent_response` / `agent_response_correction`: the canonical finalized response for a turn.
+     * Updates the matching message in place (even after it was finalized), appends when it belongs
+     * to a newer turn, and ignores a stale/unmatched event id.
+     */
+    private fun applyAgentResponse(content: String, eventId: Int?) {
+        _messages.update { current ->
+            val idx = current.messageIndex(MessageRole.AGENT, eventId)
+            when {
+                idx != null -> current.toMutableList().also {
+                    it[idx] = current[idx].copy(content = content, eventId = eventId, isPartial = false)
+                }
+                current.isNewerThanLastMessage(MessageRole.AGENT, eventId) ->
+                    current + Message(role = MessageRole.AGENT, content = content, eventId = eventId, isPartial = false)
+                else -> current
+            }
+        }
+    }
+
+    /**
+     * Finalized `user_transcript`: finalizes the matching in-progress partial, or appends when it
+     * belongs to a newer turn; then drops any leftover partial (a tentative that never produced its
+     * own final), so a final never leaves a stray partial bubble behind.
+     */
+    private fun applyUserTranscript(content: String, eventId: Int?) {
+        _messages.update { current ->
+            val idx = current.messageIndex(MessageRole.USER, eventId)
+            val reconciled = when {
+                idx != null -> current.toMutableList().also {
+                    it[idx] = current[idx].copy(content = content, eventId = eventId, isPartial = false)
+                }
+                current.isNewerThanLastMessage(MessageRole.USER, eventId) ->
+                    current + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = false)
+                else -> current
+            }
+            reconciled.filterNot { it.role == MessageRole.USER && it.isPartial }
+        }
+    }
+
+    /**
+     * `tentative_user_transcript`: the in-progress user transcript. Supersedes any existing partial,
+     * then surfaces a fresh one if it belongs to a turn newer than the last finalized transcript.
+     */
+    private fun applyTentativeUserTranscript(content: String, eventId: Int?) {
+        _messages.update { current ->
+            val withoutPartials = current.filterNot { it.role == MessageRole.USER && it.isPartial }
+            if (withoutPartials.isNewerThanLastMessage(MessageRole.USER, eventId)) {
+                withoutPartials + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = true)
+            } else {
+                withoutPartials
+            }
+        }
+    }
+
+    /** Index of the message for [role] carrying exactly [eventId], or null (never matches null ids). */
+    private fun List<Message>.messageIndex(role: MessageRole, eventId: Int?): Int? {
+        if (eventId == null) return null
+        val idx = indexOfFirst { it.role == role && it.eventId == eventId }
+        return if (idx >= 0) idx else null
+    }
+
+    /**
+     * Whether [eventId] is newer than [role]'s most recent message. Messages are appended in arrival
+     * order, so the last message of a role carries its highest event id. A null incoming id (or a
+     * role whose last message has no id) can't be ordered and is treated as newer.
+     */
+    private fun List<Message>.isNewerThanLastMessage(role: MessageRole, eventId: Int?): Boolean {
+        if (eventId == null) return true
+        val lastEventId = lastOrNull { it.role == role }?.eventId ?: return true
+        return eventId > lastEventId
+    }
+
+    /** Appends a finalized local message (no event id), e.g. text the user sends. */
+    private fun appendLocalMessage(role: MessageRole, content: String) {
+        _messages.update { it + Message(role = role, content = content, eventId = null, isPartial = false) }
+    }
+    // endregion
 
     /**
      * Clean up resources
      */
     fun cleanup() {
         scope.cancel()
-        _lastAgentEventId = null
         _lastFeedbackSentForEventIdInt = null
     }
 }

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -350,8 +350,6 @@ class ConversationEventHandler(
      * @param isPositive true for positive feedback, false for negative
      */
     fun sendFeedback(isPositive: Boolean) {
-        // The latest agent reply is the last agent message in arrival order; its event id is the
-        // feedback target.
         val lastEventId = _messages.value.lastOrNull { it.role == MessageRole.AGENT }?.eventId
         val lastFeedbackSentForEventId = _lastFeedbackSentForEventIdInt
 
@@ -410,14 +408,6 @@ class ConversationEventHandler(
      */
     fun getCurrentMode(): ConversationMode = _conversationMode.value
 
-    // region Transcript reconciliation
-    //
-    // Each transcript/response is matched against its role's messages by event id, so [messages] is
-    // consistent for any arrival order: a newer id appends a new message, a matching id updates the
-    // existing one, an older unmatched id is ignored. Messages are only appended (never reordered),
-    // so per-role event ids stay ordered and unique. A null event id can't be ordered and starts a
-    // new message.
-
     /**
      * Streaming `agent_chat_response_part`: appends text to the matching partial and finalizes it on
      * [isStop]; a finalized message is never reopened. With no match, a newer turn starts a new
@@ -443,37 +433,36 @@ class ConversationEventHandler(
 
     /**
      * `agent_response` / `agent_response_correction`: the canonical finalized response for a turn.
-     * Overwrites the matching message in place (even if already finalized), appends for a newer turn,
-     * ignores a stale/unmatched event id.
+     * Overwrites the matching message in place (even if already finalized); otherwise appends in
+     * arrival order, so a finalized response is always recorded even if its event id is out of order.
      */
     private fun applyAgentResponse(content: String, eventId: Int?) {
         _messages.update { current ->
             val idx = current.messageIndex(MessageRole.AGENT, eventId)
-            when {
-                idx != null -> current.toMutableList().also {
+            if (idx != null) {
+                current.toMutableList().also {
                     it[idx] = current[idx].copy(content = content, eventId = eventId, isPartial = false)
                 }
-                current.isNewerThanLastMessage(MessageRole.AGENT, eventId) ->
-                    current + Message(role = MessageRole.AGENT, content = content, eventId = eventId, isPartial = false)
-                else -> current
+            } else {
+                current + Message(role = MessageRole.AGENT, content = content, eventId = eventId, isPartial = false)
             }
         }
     }
 
     /**
-     * Finalized `user_transcript`: finalizes the matching partial or appends for a newer turn, then
-     * drops any leftover user partial so a final never leaves a stray partial bubble behind.
+     * Finalized `user_transcript`: updates the matching message in place or appends in arrival order
+     * (a finalized transcript is always recorded, even out of order), then drops any leftover user
+     * partial so a final never leaves a stray partial bubble behind.
      */
     private fun applyUserTranscript(content: String, eventId: Int?) {
         _messages.update { current ->
             val idx = current.messageIndex(MessageRole.USER, eventId)
-            val reconciled = when {
-                idx != null -> current.toMutableList().also {
+            val reconciled = if (idx != null) {
+                current.toMutableList().also {
                     it[idx] = current[idx].copy(content = content, eventId = eventId, isPartial = false)
                 }
-                current.isNewerThanLastMessage(MessageRole.USER, eventId) ->
-                    current + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = false)
-                else -> current
+            } else {
+                current + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = false)
             }
             reconciled.filterNot { it.role == MessageRole.USER && it.isPartial }
         }
@@ -495,32 +484,24 @@ class ConversationEventHandler(
     }
 
     /**
-     * Index of [role]'s message with exactly [eventId], or null (null ids never match).
-     *
-     * Scans from the tail and stops at the first same-role id below [eventId]: a role's ids rise with
-     * position, so the target can't be further back. This keeps the hot paths O(1) — updating the
-     * latest message or appending a newer one. Null-id local messages (typed sends) carry no order
-     * and are skipped.
+     * Index of [role]'s message with exactly [eventId], or null (null ids never match). Per-role
+     * event ids are unique but not sorted (finalized records can arrive out of order), so this scans
+     * the whole list — tail-first to favor touching the most recent message.
      */
     private fun List<Message>.messageIndex(role: MessageRole, eventId: Int?): Int? {
         if (eventId == null) return null
         for (i in lastIndex downTo 0) {
             val candidate = this[i]
-            if (candidate.role != role) continue
-            val candidateId = candidate.eventId ?: continue
-            when {
-                candidateId == eventId -> return i
-                candidateId < eventId -> return null // ids rise with position; target is absent
-            }
+            if (candidate.role == role && candidate.eventId == eventId) return i
         }
         return null
     }
 
     /**
-     * Whether [eventId] is newer than [role]'s latest server-assigned message. The last id-carrying
-     * message of a role holds its highest event id. Null-id local messages (typed sends) are skipped
-     * so they can't make a stale transcript look newer. A null incoming id (or no id-carrying
-     * message) can't be ordered and is treated as newer.
+     * Whether [eventId] is newer than [role]'s most recently appended server message. Gates
+     * in-progress partials (tentatives, streamed parts) so a stale one can't resurface. Null-id local
+     * messages (typed sends) are skipped so they can't shift the comparison. A null incoming id (or no
+     * id-carrying message yet) can't be ordered and is treated as newer.
      */
     private fun List<Message>.isNewerThanLastMessage(role: MessageRole, eventId: Int?): Boolean {
         if (eventId == null) return true
@@ -532,7 +513,6 @@ class ConversationEventHandler(
     private fun appendLocalMessage(role: MessageRole, content: String) {
         _messages.update { it + Message(role = role, content = content, eventId = null, isPartial = false) }
     }
-    // endregion
 
     /**
      * Clean up resources

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -408,34 +408,28 @@ class ConversationEventHandler(
      */
     fun getCurrentMode(): ConversationMode = _conversationMode.value
 
-    /**
-     * Streaming `agent_chat_response_part`: appends text to the matching partial and finalizes it on
-     * [isStop]; a finalized message is never reopened. With no match, a newer turn starts a new
-     * message and a stale part is ignored.
-     */
+    /** Accumulates a streaming `agent_chat_response_part` into its turn's message. */
     private fun appendAgentResponsePart(text: String, eventId: Int?, isStop: Boolean) {
         _messages.update { current ->
             val idx = current.messageIndex(MessageRole.AGENT, eventId)
             when {
                 idx != null -> {
                     val existing = current[idx]
+                    // Don't apply streaming updates to a finalized message.
                     if (!existing.isPartial) current
                     else current.toMutableList().also {
                         it[idx] = existing.copy(content = existing.content + text, eventId = eventId, isPartial = !isStop)
                     }
                 }
-                current.isNewerThanLastMessage(MessageRole.AGENT, eventId) ->
+                // With no match, only start a bubble for a new turn; ignore streaming updates with stale event_ids.
+                current.isNewerThanHighestEventId(MessageRole.AGENT, eventId) ->
                     current + Message(role = MessageRole.AGENT, content = text, eventId = eventId, isPartial = !isStop)
                 else -> current
             }
         }
     }
 
-    /**
-     * `agent_response` / `agent_response_correction`: the canonical finalized response for a turn.
-     * Overwrites the matching message in place (even if already finalized); otherwise appends in
-     * arrival order, so a finalized response is always recorded even if its event id is out of order.
-     */
+    /** Applies the canonical finalized `agent_response` / `agent_response_correction` for a turn. */
     private fun applyAgentResponse(content: String, eventId: Int?) {
         _messages.update { current ->
             val idx = current.messageIndex(MessageRole.AGENT, eventId)
@@ -449,11 +443,7 @@ class ConversationEventHandler(
         }
     }
 
-    /**
-     * Finalized `user_transcript`: updates the matching message in place or appends in arrival order
-     * (a finalized transcript is always recorded, even out of order), then drops any leftover user
-     * partial so a final never leaves a stray partial bubble behind.
-     */
+    /** Applies a finalized `user_transcript`. */
     private fun applyUserTranscript(content: String, eventId: Int?) {
         _messages.update { current ->
             val idx = current.messageIndex(MessageRole.USER, eventId)
@@ -464,49 +454,40 @@ class ConversationEventHandler(
             } else {
                 current + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = false)
             }
+            // Make sure there are no orphaned tentative user transcripts.
             reconciled.filterNot { it.role == MessageRole.USER && it.isPartial }
         }
     }
 
-    /**
-     * `tentative_user_transcript`: the in-progress user transcript. Replaces any existing partial,
-     * then re-adds it only if newer than the last finalized transcript.
-     */
+    /** Applies an in-progress `tentative_user_transcript`. */
     private fun applyTentativeUserTranscript(content: String, eventId: Int?) {
         _messages.update { current ->
+            // Make sure there are no orphaned tentative user transcripts.
             val withoutPartials = current.filterNot { it.role == MessageRole.USER && it.isPartial }
-            if (withoutPartials.isNewerThanLastMessage(MessageRole.USER, eventId)) {
+            if (withoutPartials.isNewerThanHighestEventId(MessageRole.USER, eventId)) {
                 withoutPartials + Message(role = MessageRole.USER, content = content, eventId = eventId, isPartial = true)
             } else {
+                // Ignore tentative user transcripts with stale event ids.
                 withoutPartials
             }
         }
     }
 
-    /**
-     * Index of [role]'s message with exactly [eventId], or null (null ids never match). Per-role
-     * event ids are unique but not sorted (finalized records can arrive out of order), so this scans
-     * the whole list — tail-first to favor touching the most recent message.
-     */
+    /** Index of [role]'s message with exactly [eventId], or null (null ids never match). */
     private fun List<Message>.messageIndex(role: MessageRole, eventId: Int?): Int? {
         if (eventId == null) return null
-        for (i in lastIndex downTo 0) {
-            val candidate = this[i]
-            if (candidate.role == role && candidate.eventId == eventId) return i
-        }
-        return null
+        // Ids are unique per role but unsorted (finals can arrive late), so scan fully; tail-first
+        // keeps the common "touch the latest message" case cheap.
+        return indexOfLast { it.role == role && it.eventId == eventId }.takeIf { it >= 0 }
     }
 
-    /**
-     * Whether [eventId] is newer than [role]'s most recently appended server message. Gates
-     * in-progress partials (tentatives, streamed parts) so a stale one can't resurface. Null-id local
-     * messages (typed sends) are skipped so they can't shift the comparison. A null incoming id (or no
-     * id-carrying message yet) can't be ordered and is treated as newer.
-     */
-    private fun List<Message>.isNewerThanLastMessage(role: MessageRole, eventId: Int?): Boolean {
+    /** Whether [eventId] is newer than the highest event id [role] has recorded. */
+    private fun List<Message>.isNewerThanHighestEventId(role: MessageRole, eventId: Int?): Boolean {
         if (eventId == null) return true
-        val lastEventId = lastOrNull { it.role == role && it.eventId != null }?.eventId ?: return true
-        return eventId > lastEventId
+        // Take the max, not the last: finals can append out of order, and null-id local (typed)
+        // messages carry no order, so they're skipped.
+        val highestEventId = mapNotNull { if (it.role == role) it.eventId else null }.maxOrNull() ?: return true
+        return eventId > highestEventId
     }
 
     /** Appends a finalized local message (no event id), e.g. text the user sends. */

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSession.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSession.kt
@@ -3,6 +3,7 @@ package io.elevenlabs
 import io.elevenlabs.models.ConversationEvent
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
+import io.elevenlabs.models.Message
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -28,7 +29,14 @@ interface ConversationSession {
      */
     val mode: StateFlow<ConversationMode>
 
-    // Message history is intentionally not tracked; rely on server transcripts
+    /**
+     * The conversation transcript, reconciled by the SDK.
+     *
+     * Emits the full, ordered list of [Message]s whenever it changes. Messages update in
+     * place via [Message.isPartial] as they stream in. Prefer this for UI binding over
+     * assembling a transcript from individual callbacks.
+     */
+    val messages: StateFlow<List<Message>>
 
     /**
      * Whether the microphone is currently muted

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
@@ -6,6 +6,7 @@ import io.elevenlabs.audio.AudioManager
 import io.elevenlabs.audio.LiveKitAudioManager
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
+import io.elevenlabs.models.Message
 import io.elevenlabs.models.toConversationStatus
 import io.elevenlabs.network.BaseConnection
 import io.elevenlabs.network.ConversationEventParser
@@ -87,6 +88,7 @@ internal class ConversationSessionImpl(
     // Public observable properties exposed as StateFlow
     override val status: StateFlow<ConversationStatus> = _status
     override val mode: StateFlow<ConversationMode> = eventHandler.conversationMode
+    override val messages: StateFlow<List<Message>> = eventHandler.messages
     override val isMuted: StateFlow<Boolean> =
         if (audioManager is LiveKitAudioManager) {
             audioManager.muteState

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
@@ -26,10 +26,15 @@ sealed class ConversationEvent {
     /**
      * Streaming agent chat response parts
      * type lifecycle: start -> delta... -> stop
+     *
+     * @param partType The part's position in the lifecycle ("start" | "delta" | "stop")
+     * @param text The text chunk for this part
+     * @param eventId Server event id used to correlate parts of the same streamed message
      */
     data class AgentChatResponsePart(
-        val partType: String, // "start" | "delta" | "stop"
-        val text: String
+        val partType: String,
+        val text: String,
+        val eventId: Int? = null
     ) : ConversationEvent()
 
     /**
@@ -75,9 +80,11 @@ sealed class ConversationEvent {
      * Event representing a response from the agent
      *
      * @param agentResponse The agent's response text
+     * @param eventId Server event id used to correlate this message in the transcript
      */
     data class AgentResponse(
         val agentResponse: String,
+        val eventId: Int? = null,
     ) : ConversationEvent()
 
     /**
@@ -85,19 +92,23 @@ sealed class ConversationEvent {
      *
      * @param originalAgentResponse The original agent response text
      * @param correctedAgentResponse The corrected agent response text
+     * @param eventId Server event id used to correlate this message in the transcript
      */
     data class AgentResponseCorrection(
         val originalAgentResponse: String,
         val correctedAgentResponse: String,
+        val eventId: Int? = null,
     ) : ConversationEvent()
 
     /**
      * Event representing user speech transcription
      *
      * @param userTranscript The transcribed user speech
+     * @param eventId Server event id used to correlate this message in the transcript
      */
     data class UserTranscript(
         val userTranscript: String,
+        val eventId: Int? = null,
     ) : ConversationEvent()
 
     /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/Message.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/Message.kt
@@ -1,20 +1,28 @@
 package io.elevenlabs.models
 
+import java.util.UUID
+
 /**
- * Represents a message in the conversation
+ * A single entry in the conversation transcript, reconciled by the SDK and exposed via
+ * [io.elevenlabs.ConversationSession.messages].
  *
- * @param id Unique integer identifier for the message
- * @param content The text content of the message
- * @param role Who sent the message (user or agent)
- * @param timestamp When the message was sent
- * @param metadata Additional metadata about the message
+ * @param id Stable identifier, preserved across in-place updates so list diffing
+ *   (e.g. `LazyColumn`/`RecyclerView` keys) stays consistent.
+ * @param role Who produced the message (user or agent).
+ * @param content The text content; grows as a partial message streams in.
+ * @param timestamp Creation time in epoch milliseconds, preserved across updates.
+ * @param eventId Server event id correlating updates for the same message; `null` for
+ *   locally appended messages.
+ * @param isPartial `true` while still being assembled (streaming agent response or
+ *   in-progress user transcript); `false` once finalized. Local messages are always `false`.
  */
 data class Message(
-    val id: Int,
-    val content: String,
+    val id: String = UUID.randomUUID().toString(),
     val role: MessageRole,
+    val content: String,
     val timestamp: Long = System.currentTimeMillis(),
-    val metadata: Map<String, Any> = emptyMap()
+    val eventId: Int? = null,
+    val isPartial: Boolean = false
 )
 
 /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
@@ -88,13 +88,22 @@ object ConversationEventParser {
         return jsonObject.get("type")?.asString
     }
 
+    /** Extracts an optional `event_id`, or null when absent/JSON null. */
+    private fun JsonObject?.parseEventId(): Int? {
+        val element = this?.get("event_id") ?: return null
+        return if (element.isJsonNull) null else element.asInt
+    }
+
     /**
      * Parse agent response event
      */
     private fun parseAgentResponse(jsonObject: JsonObject): ConversationEvent.AgentResponse {
         val obj = jsonObject.getAsJsonObject("agent_response_event")
         val content = obj?.get("agent_response")?.asString ?: ""
-        return ConversationEvent.AgentResponse(agentResponse = content)
+        return ConversationEvent.AgentResponse(
+            agentResponse = content,
+            eventId = obj.parseEventId()
+        )
     }
 
     /**
@@ -103,7 +112,10 @@ object ConversationEventParser {
     private fun parseUserTranscript(jsonObject: JsonObject): ConversationEvent.UserTranscript {
         val obj = jsonObject.getAsJsonObject("user_transcription_event")
         val content = obj?.get("user_transcript")?.asString ?: ""
-        return ConversationEvent.UserTranscript(userTranscript = content)
+        return ConversationEvent.UserTranscript(
+            userTranscript = content,
+            eventId = obj.parseEventId()
+        )
     }
 
     /**
@@ -164,7 +176,11 @@ object ConversationEventParser {
         val obj = jsonObject.getAsJsonObject("agent_response_correction_event") ?: jsonObject
         val original = obj.get("original_agent_response")?.asString ?: ""
         val corrected = obj.get("corrected_agent_response")?.asString ?: ""
-        return ConversationEvent.AgentResponseCorrection(originalAgentResponse = original, correctedAgentResponse = corrected)
+        return ConversationEvent.AgentResponseCorrection(
+            originalAgentResponse = original,
+            correctedAgentResponse = corrected,
+            eventId = obj.parseEventId()
+        )
     }
 
     private fun parseAgentToolResponse(jsonObject: JsonObject): ConversationEvent.AgentToolResponse {
@@ -286,7 +302,8 @@ object ConversationEventParser {
         val type = obj.get("type")?.asString ?: ""
         return ConversationEvent.AgentChatResponsePart(
             partType = type,
-            text = text
+            text = text,
+            eventId = obj.parseEventId()
         )
     }
 

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
@@ -3,20 +3,22 @@ package io.elevenlabs
 import io.elevenlabs.audio.AudioManager
 import io.elevenlabs.models.ConversationEvent
 import io.elevenlabs.models.MessageRole
-import io.elevenlabs.network.OutgoingEvent
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 /**
- * Tests for the reconciled transcript exposed via [ConversationSession.messages]:
- * upsert-by-event-id, in-place updates, streaming accumulation, partial/final flags,
- * optimistic local sends, and arrival ordering without cross-role merging.
+ * Behavior of the reconciled transcript exposed via [ConversationEventHandler.messages].
+ *
+ * Incoming transcripts/responses are matched per role by event id: a matching id updates the
+ * existing message in place, a newer id appends, and a stale unmatched id is ignored. An
+ * in-progress user partial never survives once its turn is finalized.
  */
 class ConversationEventHandlerMessagesTest {
 
@@ -40,173 +42,53 @@ class ConversationEventHandlerMessagesTest {
         toolRegistry.cleanup()
     }
 
-    @Test
-    fun `agent_response appends a final agent message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hello there", eventId = 1))
+    // --- Agent streaming (agent_chat_response_part) ---
 
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals(MessageRole.AGENT, messages[0].role)
-        assertEquals("Hello there", messages[0].content)
-        assertEquals(1, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
+    @Test
+    fun `streaming agent parts accumulate into one message and finalize on stop`() = runTest {
+        handler.handleIncomingEvent(part("start", "Hel", 7))
+        handler.handleIncomingEvent(part("delta", "lo ", 7))
+        handler.handleIncomingEvent(part("delta", "world", 7))
+
+        var message = handler.messages.value.single()
+        assertEquals("Hello world", message.content)
+        assertTrue(message.isPartial)
+        val streamingId = message.id
+
+        handler.handleIncomingEvent(part("stop", "!", 7))
+
+        message = handler.messages.value.single()
+        assertEquals("Hello world!", message.content)
+        assertFalse(message.isPartial)
+        assertEquals("message identity must be stable across updates", streamingId, message.id)
     }
 
     @Test
-    fun `streaming parts accumulate into one partial message and finalize on stop`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hel", eventId = 7))
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = "lo ", eventId = 7))
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = "world", eventId = 7))
+    fun `a streaming part is ignored once the agent message is finalized`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "final answer", eventId = 1))
 
-        var messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("Hello world", messages[0].content)
-        assertTrue("message should be partial while streaming", messages[0].isPartial)
-        val idDuringStream = messages[0].id
+        handler.handleIncomingEvent(part("delta", " late", 1))
 
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "!", eventId = 7))
-
-        messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("Hello world!", messages[0].content)
-        assertFalse("message should be final after stop", messages[0].isPartial)
-        assertEquals("id must be preserved across updates", idDuringStream, messages[0].id)
+        val message = handler.messages.value.single()
+        assertEquals("final answer", message.content)
+        assertFalse(message.isPartial)
     }
 
-    @Test
-    fun `final agent_response finalizes a still-streaming partial in place`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hi", eventId = 3))
+    // --- Agent response / correction ---
 
-        // The full response for the same (not newer) event id arrives while the streamed message is
-        // still partial: it updates the existing message in place and finalizes it.
+    @Test
+    fun `agent_response finalizes a streaming partial in place`() = runTest {
+        handler.handleIncomingEvent(part("start", "Hi", 3))
+
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hi, how can I help?", eventId = 3))
 
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("Hi, how can I help?", messages[0].content)
-        assertFalse(messages[0].isPartial)
+        val message = handler.messages.value.single()
+        assertEquals("Hi, how can I help?", message.content)
+        assertFalse(message.isPartial)
     }
 
     @Test
-    fun `agent_response overwrites a finalized streamed message for the same event id`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hi", eventId = 3))
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "", eventId = 3))
-
-        // agent_response is canonical for its turn: a later one with the same event id replaces the
-        // stored content in place, even after the streamed message was finalized.
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hi, how can I help?", eventId = 3))
-
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("Hi, how can I help?", messages[0].content)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `consecutive tentative user transcripts collapse into one partial`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
-
-        val messages = handler.messages.value
-        assertEquals("consecutive tentatives must collapse to one bubble, not duplicate", 1, messages.size)
-        assertEquals(MessageRole.USER, messages[0].role)
-        assertEquals("hello the", messages[0].content)
-        assertTrue(messages[0].isPartial)
-    }
-
-    @Test
-    fun `final user_transcript replaces the in-progress partial with a single final message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
-
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
-
-        val messages = handler.messages.value
-        assertEquals("the partial must be replaced, not duplicated", 1, messages.size)
-        assertEquals(MessageRole.USER, messages[0].role)
-        assertEquals("hello there", messages[0].content)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `a late tentative transcript does not overwrite a finalized one`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
-
-        // A stray tentative for the same event id arriving after finalization must be ignored.
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello th", eventId = 5))
-
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("hello there", messages[0].content)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `a newer tentative supersedes a stray partial with a different event id`() = runTest {
-        // A tentative that never finalizes, followed by a newer tentative (higher event id): the
-        // stray must be superseded in place, not left behind as a second user bubble.
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up.", eventId = 245))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up a good test.", eventId = 249))
-
-        var messages = handler.messages.value
-        assertEquals("a newer tentative must replace the stray partial, not append", 1, messages.size)
-        assertEquals("Set up a good test.", messages[0].content)
-        assertTrue(messages[0].isPartial)
-
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "Set up a good test.", eventId = 249))
-
-        messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("Set up a good test.", messages[0].content)
-        assertEquals(249, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `a final transcript supersedes a stray partial with a different event id`() = runTest {
-        // A tentative with one id followed directly by a final with a higher id (no intermediate
-        // tentative) must collapse to a single final message.
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Any questions?", eventId = 468))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "I have a question. Sorry.", eventId = 475))
-
-        val messages = handler.messages.value
-        assertEquals("final must drop the stray partial, not append a second bubble", 1, messages.size)
-        assertEquals("I have a question. Sorry.", messages[0].content)
-        assertEquals(475, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `a stray partial is dropped when an agent message intervenes`() = runTest {
-        // A tentative that never finalized, then an agent reply, then a new user transcript: the
-        // stray partial is dropped and the new transcript is appended after the agent (arrival order).
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "stray", eventId = 10))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "agent reply", eventId = 11))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "real question", eventId = 12))
-
-        val messages = handler.messages.value
-        assertEquals("stray partial must be dropped, not kept", 2, messages.size)
-        assertEquals(MessageRole.AGENT, messages[0].role)
-        assertEquals("agent reply", messages[0].content)
-        assertEquals(MessageRole.USER, messages[1].role)
-        assertEquals("real question", messages[1].content)
-        assertFalse(messages[1].isPartial)
-    }
-
-    @Test
-    fun `a stale agent event with a lower id is ignored`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "current", eventId = 10))
-        // An out-of-order event id older than the high-water mark, matching no existing message, is dropped.
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "stale", eventId = 4))
-
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("current", messages[0].content)
-    }
-
-    @Test
-    fun `agent_response_correction replaces content in place`() = runTest {
+    fun `agent_response_correction replaces the matching agent message`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "It is sunny", eventId = 9))
 
         handler.handleIncomingEvent(
@@ -217,27 +99,107 @@ class ConversationEventHandlerMessagesTest {
             )
         )
 
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("It is raining", messages[0].content)
+        val message = handler.messages.value.single()
+        assertEquals("It is raining", message.content)
+        assertFalse(message.isPartial)
     }
 
     @Test
-    fun `sendUserMessage optimistically appends a final local user message`() {
-        handler.sendUserMessage("Book a flight")
+    fun `agent_response with a newer event id appends a new message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "first", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "second", eventId = 2))
 
         val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals(MessageRole.USER, messages[0].role)
-        assertEquals("Book a flight", messages[0].content)
-        assertEquals(null, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
+        assertEquals(listOf("first", "second"), messages.map { it.content })
+        assertEquals(listOf(1, 2), messages.map { it.eventId })
     }
 
     @Test
-    fun `user and agent messages sharing an event id stay distinct and in arrival order`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "agent reply", eventId = 5))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "user said this", eventId = 5))
+    fun `an out-of-order agent_response with a stale event id is ignored`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "current", eventId = 10))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "stale", eventId = 4))
+
+        val message = handler.messages.value.single()
+        assertEquals("current", message.content)
+        assertEquals(10, message.eventId)
+    }
+
+    // --- User tentative (tentative_user_transcript) ---
+
+    @Test
+    fun `tentative user transcripts for one turn collapse into a single partial`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+
+        val message = handler.messages.value.single()
+        assertEquals(MessageRole.USER, message.role)
+        assertEquals("hello the", message.content)
+        assertTrue(message.isPartial)
+    }
+
+    @Test
+    fun `a newer tentative replaces a stray partial instead of duplicating it`() = runTest {
+        // A tentative that never finalized, then a newer one: the stale partial must not linger.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up.", eventId = 245))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up a test.", eventId = 249))
+
+        val message = handler.messages.value.single()
+        assertEquals("Set up a test.", message.content)
+        assertEquals(249, message.eventId)
+        assertTrue(message.isPartial)
+    }
+
+    @Test
+    fun `a tentative is ignored once the turn is finalized`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
+        // A stray tentative arriving after the final must not reopen a partial bubble.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello th", eventId = 5))
+
+        val message = handler.messages.value.single()
+        assertEquals("hello there", message.content)
+        assertFalse(message.isPartial)
+    }
+
+    // --- User transcript (final) ---
+
+    @Test
+    fun `user_transcript finalizes the in-progress partial`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
+
+        val message = handler.messages.value.single()
+        assertEquals("hello there", message.content)
+        assertFalse(message.isPartial)
+    }
+
+    @Test
+    fun `user_transcript for a new turn appends and clears a stray partial`() = runTest {
+        // The id-468 partial never finalized; the next turn's final (id 475) must drop it.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Any questions?", eventId = 468))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "I have one.", eventId = 475))
+
+        val message = handler.messages.value.single()
+        assertEquals("I have one.", message.content)
+        assertEquals(475, message.eventId)
+        assertFalse(message.isPartial)
+    }
+
+    @Test
+    fun `an out-of-order user_transcript with a stale event id is ignored`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "current", eventId = 20))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 10))
+
+        val message = handler.messages.value.single()
+        assertEquals("current", message.content)
+        assertEquals(20, message.eventId)
+    }
+
+    // --- Cross-role, local sends, ordering ---
+
+    @Test
+    fun `user and agent messages with the same event id stay distinct`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "agent", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "user", eventId = 5))
 
         val messages = handler.messages.value
         assertEquals(2, messages.size)
@@ -246,146 +208,46 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `agent_response overwrites a finalized message for the same event id`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "first final", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "revised final", eventId = 1))
+    fun `sendUserMessage appends a local user message without an event id`() {
+        handler.sendUserMessage("Book a flight")
 
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("revised final", messages[0].content)
-        assertEquals(1, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
+        val message = handler.messages.value.single()
+        assertEquals(MessageRole.USER, message.role)
+        assertEquals("Book a flight", message.content)
+        assertNull(message.eventId)
+        assertFalse(message.isPartial)
     }
 
     @Test
-    fun `agent_response_correction with an unknown event id appends`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "kept as-is", eventId = 100))
-        handler.handleIncomingEvent(
-            ConversationEvent.AgentResponseCorrection(
-                originalAgentResponse = "x",
-                correctedAgentResponse = "y",
-                eventId = 999
-            )
-        )
-
-        val messages = handler.messages.value
-        assertEquals(2, messages.size)
-        assertEquals("kept as-is", messages[0].content)
-        assertEquals(100, messages[0].eventId)
-        assertEquals("y", messages[1].content)
-        assertEquals(999, messages[1].eventId)
-    }
-
-    @Test
-    fun `user_transcript overwrites a finalized message for the same event id`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first final", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "revised final", eventId = 1))
-
-        val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("revised final", messages[0].content)
-        assertEquals(1, messages[0].eventId)
-        assertFalse(messages[0].isPartial)
-    }
-
-    @Test
-    fun `a stale user transcript with a lower id is ignored`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "current", eventId = 20))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 10))
-
-        val messages = handler.messages.value
-        assertEquals("a stale, unmatched transcript must be ignored", 1, messages.size)
-        assertEquals("current", messages[0].content)
-        assertEquals(20, messages[0].eventId)
-    }
-
-    // region Message store consistency rules
-    //
-    // These exercise the guarantees the store maintains for any event sequence:
-    // 1. Absolute order follows the arrival of finalized transcripts/responses (append-only).
-    // 2. At most one in-progress (partial) user transcript exists at a time.
-    // 3. User messages stay ordered by event id with no duplicates.
-    // 4. Agent messages stay ordered by event id with no duplicates.
-    // 5. A partial never overwrites a finalized message; older, unmatched event ids are ignored.
-
-    @Test
-    fun `rule 1 - final order follows arrival of finalized messages`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "u1", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "a1", eventId = 2))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "u2", eventId = 3))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "a2", eventId = 4))
-
-        val messages = handler.messages.value
-        assertEquals(listOf("u1", "a1", "u2", "a2"), messages.map { it.content })
-        assertEquals(
-            listOf(MessageRole.USER, MessageRole.AGENT, MessageRole.USER, MessageRole.AGENT),
-            messages.map { it.role }
-        )
-    }
-
-    @Test
-    fun `rule 2 - at most one partial user transcript while an agent streams`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "u partial", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "a", eventId = 2))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "u partial revised", eventId = 3))
-
-        val messages = handler.messages.value
-        val partialUsers = messages.filter { it.role == MessageRole.USER && it.isPartial }
-        assertEquals(1, partialUsers.size)
-        assertEquals("u partial revised", partialUsers[0].content)
-        assertEquals(3, partialUsers[0].eventId)
-        // The concurrently-streaming agent partial is untouched.
-        assertEquals(1, messages.count { it.role == MessageRole.AGENT && it.isPartial })
-    }
-
-    @Test
-    fun `rule 3 - user transcripts remain ordered and unique by event id`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "p", eventId = 10))
+    fun `a locally typed message does not let a later stale transcript reappear`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first", eventId = 10))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "second", eventId = 20))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "third", eventId = 30))
-
-        val userIds = handler.messages.value.filter { it.role == MessageRole.USER }.mapNotNull { it.eventId }
-        assertEquals(listOf(10, 20, 30), userIds)
-        assertEquals("no duplicate user event ids", userIds.toSet().size, userIds.size)
-    }
-
-    @Test
-    fun `rule 4 - agent responses remain ordered and unique by event id`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "h", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "i", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "hi", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "next", eventId = 2))
-
-        val agentIds = handler.messages.value.filter { it.role == MessageRole.AGENT }.mapNotNull { it.eventId }
-        assertEquals(listOf(1, 2), agentIds)
-        assertEquals("no duplicate agent event ids", agentIds.toSet().size, agentIds.size)
-    }
-
-    @Test
-    fun `rule 5 - a late streaming part does not overwrite a finalized agent message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "final answer", eventId = 1))
-        assertFalse(handler.messages.value.last().isPartial)
-
-        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = " late", eventId = 1))
+        // The typed message carries no event id, so it must not lower the role's high-water mark.
+        handler.sendUserMessage("typed")
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 5))
 
         val messages = handler.messages.value
-        assertEquals(1, messages.size)
-        assertEquals("partial must not overwrite finalized content", "final answer", messages[0].content)
-        assertFalse("partial must not downgrade a finalized message", messages[0].isPartial)
+        assertEquals(listOf("first", "typed"), messages.map { it.content })
+        assertEquals(listOf(10, null), messages.map { it.eventId })
     }
 
     @Test
-    fun `rule 5 - a new tentative does not overwrite a finalized user message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "committed", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "typing", eventId = 2))
+    fun `a full voice turn reconciles streamed and finalized text into ordered messages`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "what's the", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "what's the weather?", eventId = 1))
+        handler.handleIncomingEvent(part("start", "It's", 2))
+        handler.handleIncomingEvent(part("delta", " sunny", 2))
+        handler.handleIncomingEvent(part("stop", ".", 2))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "It's sunny.", eventId = 2))
 
         val messages = handler.messages.value
         assertEquals(2, messages.size)
-        assertEquals("committed", messages[0].content)
-        assertFalse(messages[0].isPartial)
-        assertEquals("typing", messages[1].content)
-        assertTrue(messages[1].isPartial)
+        assertEquals(MessageRole.USER, messages[0].role)
+        assertEquals("what's the weather?", messages[0].content)
+        assertEquals(MessageRole.AGENT, messages[1].role)
+        assertEquals("It's sunny.", messages[1].content)
+        assertTrue("no partial bubbles should remain", messages.none { it.isPartial })
     }
-    // endregion
+
+    private fun part(partType: String, text: String, eventId: Int) =
+        ConversationEvent.AgentChatResponsePart(partType = partType, text = text, eventId = eventId)
 }

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
@@ -1,0 +1,391 @@
+package io.elevenlabs
+
+import io.elevenlabs.audio.AudioManager
+import io.elevenlabs.models.ConversationEvent
+import io.elevenlabs.models.MessageRole
+import io.elevenlabs.network.OutgoingEvent
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for the reconciled transcript exposed via [ConversationSession.messages]:
+ * upsert-by-event-id, in-place updates, streaming accumulation, partial/final flags,
+ * optimistic local sends, and arrival ordering without cross-role merging.
+ */
+class ConversationEventHandlerMessagesTest {
+
+    private lateinit var audioManager: AudioManager
+    private lateinit var toolRegistry: ClientToolRegistry
+    private lateinit var handler: ConversationEventHandler
+
+    @Before
+    fun setup() {
+        audioManager = mockk(relaxed = true)
+        toolRegistry = ClientToolRegistry()
+        handler = ConversationEventHandler(
+            audioManager = audioManager,
+            toolRegistry = toolRegistry,
+            messageCallback = { }
+        )
+    }
+
+    @After
+    fun teardown() {
+        toolRegistry.cleanup()
+    }
+
+    @Test
+    fun `agent_response appends a final agent message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hello there", eventId = 1))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals(MessageRole.AGENT, messages[0].role)
+        assertEquals("Hello there", messages[0].content)
+        assertEquals(1, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `streaming parts accumulate into one partial message and finalize on stop`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hel", eventId = 7))
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = "lo ", eventId = 7))
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = "world", eventId = 7))
+
+        var messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("Hello world", messages[0].content)
+        assertTrue("message should be partial while streaming", messages[0].isPartial)
+        val idDuringStream = messages[0].id
+
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "!", eventId = 7))
+
+        messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("Hello world!", messages[0].content)
+        assertFalse("message should be final after stop", messages[0].isPartial)
+        assertEquals("id must be preserved across updates", idDuringStream, messages[0].id)
+    }
+
+    @Test
+    fun `final agent_response finalizes a still-streaming partial in place`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hi", eventId = 3))
+
+        // The full response for the same (not newer) event id arrives while the streamed message is
+        // still partial: it updates the existing message in place and finalizes it.
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hi, how can I help?", eventId = 3))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("Hi, how can I help?", messages[0].content)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `agent_response overwrites a finalized streamed message for the same event id`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "Hi", eventId = 3))
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "", eventId = 3))
+
+        // agent_response is canonical for its turn: a later one with the same event id replaces the
+        // stored content in place, even after the streamed message was finalized.
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hi, how can I help?", eventId = 3))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("Hi, how can I help?", messages[0].content)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `consecutive tentative user transcripts collapse into one partial`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+
+        val messages = handler.messages.value
+        assertEquals("consecutive tentatives must collapse to one bubble, not duplicate", 1, messages.size)
+        assertEquals(MessageRole.USER, messages[0].role)
+        assertEquals("hello the", messages[0].content)
+        assertTrue(messages[0].isPartial)
+    }
+
+    @Test
+    fun `final user_transcript replaces the in-progress partial with a single final message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
+
+        val messages = handler.messages.value
+        assertEquals("the partial must be replaced, not duplicated", 1, messages.size)
+        assertEquals(MessageRole.USER, messages[0].role)
+        assertEquals("hello there", messages[0].content)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `a late tentative transcript does not overwrite a finalized one`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
+
+        // A stray tentative for the same event id arriving after finalization must be ignored.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello th", eventId = 5))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("hello there", messages[0].content)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `a newer tentative supersedes a stray partial with a different event id`() = runTest {
+        // A tentative that never finalizes, followed by a newer tentative (higher event id): the
+        // stray must be superseded in place, not left behind as a second user bubble.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up.", eventId = 245))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up a good test.", eventId = 249))
+
+        var messages = handler.messages.value
+        assertEquals("a newer tentative must replace the stray partial, not append", 1, messages.size)
+        assertEquals("Set up a good test.", messages[0].content)
+        assertTrue(messages[0].isPartial)
+
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "Set up a good test.", eventId = 249))
+
+        messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("Set up a good test.", messages[0].content)
+        assertEquals(249, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `a final transcript supersedes a stray partial with a different event id`() = runTest {
+        // A tentative with one id followed directly by a final with a higher id (no intermediate
+        // tentative) must collapse to a single final message.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Any questions?", eventId = 468))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "I have a question. Sorry.", eventId = 475))
+
+        val messages = handler.messages.value
+        assertEquals("final must drop the stray partial, not append a second bubble", 1, messages.size)
+        assertEquals("I have a question. Sorry.", messages[0].content)
+        assertEquals(475, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `a stray partial is dropped when an agent message intervenes`() = runTest {
+        // A tentative that never finalized, then an agent reply, then a new user transcript: the
+        // stray partial is dropped and the new transcript is appended after the agent (arrival order).
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "stray", eventId = 10))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "agent reply", eventId = 11))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "real question", eventId = 12))
+
+        val messages = handler.messages.value
+        assertEquals("stray partial must be dropped, not kept", 2, messages.size)
+        assertEquals(MessageRole.AGENT, messages[0].role)
+        assertEquals("agent reply", messages[0].content)
+        assertEquals(MessageRole.USER, messages[1].role)
+        assertEquals("real question", messages[1].content)
+        assertFalse(messages[1].isPartial)
+    }
+
+    @Test
+    fun `a stale agent event with a lower id is ignored`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "current", eventId = 10))
+        // An out-of-order event id older than the high-water mark, matching no existing message, is dropped.
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "stale", eventId = 4))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("current", messages[0].content)
+    }
+
+    @Test
+    fun `agent_response_correction replaces content in place`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "It is sunny", eventId = 9))
+
+        handler.handleIncomingEvent(
+            ConversationEvent.AgentResponseCorrection(
+                originalAgentResponse = "It is sunny",
+                correctedAgentResponse = "It is raining",
+                eventId = 9
+            )
+        )
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("It is raining", messages[0].content)
+    }
+
+    @Test
+    fun `sendUserMessage optimistically appends a final local user message`() {
+        handler.sendUserMessage("Book a flight")
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals(MessageRole.USER, messages[0].role)
+        assertEquals("Book a flight", messages[0].content)
+        assertEquals(null, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `user and agent messages sharing an event id stay distinct and in arrival order`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "agent reply", eventId = 5))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "user said this", eventId = 5))
+
+        val messages = handler.messages.value
+        assertEquals(2, messages.size)
+        assertEquals(MessageRole.AGENT, messages[0].role)
+        assertEquals(MessageRole.USER, messages[1].role)
+    }
+
+    @Test
+    fun `agent_response overwrites a finalized message for the same event id`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "first final", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "revised final", eventId = 1))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("revised final", messages[0].content)
+        assertEquals(1, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `agent_response_correction with an unknown event id appends`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "kept as-is", eventId = 100))
+        handler.handleIncomingEvent(
+            ConversationEvent.AgentResponseCorrection(
+                originalAgentResponse = "x",
+                correctedAgentResponse = "y",
+                eventId = 999
+            )
+        )
+
+        val messages = handler.messages.value
+        assertEquals(2, messages.size)
+        assertEquals("kept as-is", messages[0].content)
+        assertEquals(100, messages[0].eventId)
+        assertEquals("y", messages[1].content)
+        assertEquals(999, messages[1].eventId)
+    }
+
+    @Test
+    fun `user_transcript overwrites a finalized message for the same event id`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first final", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "revised final", eventId = 1))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("revised final", messages[0].content)
+        assertEquals(1, messages[0].eventId)
+        assertFalse(messages[0].isPartial)
+    }
+
+    @Test
+    fun `a stale user transcript with a lower id is ignored`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "current", eventId = 20))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 10))
+
+        val messages = handler.messages.value
+        assertEquals("a stale, unmatched transcript must be ignored", 1, messages.size)
+        assertEquals("current", messages[0].content)
+        assertEquals(20, messages[0].eventId)
+    }
+
+    // region Message store consistency rules
+    //
+    // These exercise the guarantees the store maintains for any event sequence:
+    // 1. Absolute order follows the arrival of finalized transcripts/responses (append-only).
+    // 2. At most one in-progress (partial) user transcript exists at a time.
+    // 3. User messages stay ordered by event id with no duplicates.
+    // 4. Agent messages stay ordered by event id with no duplicates.
+    // 5. A partial never overwrites a finalized message; older, unmatched event ids are ignored.
+
+    @Test
+    fun `rule 1 - final order follows arrival of finalized messages`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "u1", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "a1", eventId = 2))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "u2", eventId = 3))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "a2", eventId = 4))
+
+        val messages = handler.messages.value
+        assertEquals(listOf("u1", "a1", "u2", "a2"), messages.map { it.content })
+        assertEquals(
+            listOf(MessageRole.USER, MessageRole.AGENT, MessageRole.USER, MessageRole.AGENT),
+            messages.map { it.role }
+        )
+    }
+
+    @Test
+    fun `rule 2 - at most one partial user transcript while an agent streams`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "u partial", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "a", eventId = 2))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "u partial revised", eventId = 3))
+
+        val messages = handler.messages.value
+        val partialUsers = messages.filter { it.role == MessageRole.USER && it.isPartial }
+        assertEquals(1, partialUsers.size)
+        assertEquals("u partial revised", partialUsers[0].content)
+        assertEquals(3, partialUsers[0].eventId)
+        // The concurrently-streaming agent partial is untouched.
+        assertEquals(1, messages.count { it.role == MessageRole.AGENT && it.isPartial })
+    }
+
+    @Test
+    fun `rule 3 - user transcripts remain ordered and unique by event id`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "p", eventId = 10))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first", eventId = 10))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "second", eventId = 20))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "third", eventId = 30))
+
+        val userIds = handler.messages.value.filter { it.role == MessageRole.USER }.mapNotNull { it.eventId }
+        assertEquals(listOf(10, 20, 30), userIds)
+        assertEquals("no duplicate user event ids", userIds.toSet().size, userIds.size)
+    }
+
+    @Test
+    fun `rule 4 - agent responses remain ordered and unique by event id`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "start", text = "h", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "stop", text = "i", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "hi", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "next", eventId = 2))
+
+        val agentIds = handler.messages.value.filter { it.role == MessageRole.AGENT }.mapNotNull { it.eventId }
+        assertEquals(listOf(1, 2), agentIds)
+        assertEquals("no duplicate agent event ids", agentIds.toSet().size, agentIds.size)
+    }
+
+    @Test
+    fun `rule 5 - a late streaming part does not overwrite a finalized agent message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "final answer", eventId = 1))
+        assertFalse(handler.messages.value.last().isPartial)
+
+        handler.handleIncomingEvent(ConversationEvent.AgentChatResponsePart(partType = "delta", text = " late", eventId = 1))
+
+        val messages = handler.messages.value
+        assertEquals(1, messages.size)
+        assertEquals("partial must not overwrite finalized content", "final answer", messages[0].content)
+        assertFalse("partial must not downgrade a finalized message", messages[0].isPartial)
+    }
+
+    @Test
+    fun `rule 5 - a new tentative does not overwrite a finalized user message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "committed", eventId = 1))
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "typing", eventId = 2))
+
+        val messages = handler.messages.value
+        assertEquals(2, messages.size)
+        assertEquals("committed", messages[0].content)
+        assertFalse(messages[0].isPartial)
+        assertEquals("typing", messages[1].content)
+        assertTrue(messages[1].isPartial)
+    }
+    // endregion
+}

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
@@ -115,13 +115,33 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `an out-of-order agent_response with a stale event id is ignored`() = runTest {
+    fun `an out-of-order agent_response is still recorded in arrival order`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "current", eventId = 10))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "stale", eventId = 4))
+        // A finalized response is canonical: a lower (out-of-order) event id is kept, not dropped.
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "earlier", eventId = 4))
 
-        val message = handler.messages.value.single()
-        assertEquals("current", message.content)
-        assertEquals(10, message.eventId)
+        val messages = handler.messages.value
+        assertEquals(listOf("current", "earlier"), messages.map { it.content })
+        assertEquals(listOf(10, 4), messages.map { it.eventId })
+    }
+
+    @Test
+    fun `a correction matches an out-of-order event id without duplicating`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "ten", eventId = 10))
+        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "four", eventId = 4))
+
+        // id 10 now sits before id 4 in the list, so the matcher must scan past the lower id to find it.
+        handler.handleIncomingEvent(
+            ConversationEvent.AgentResponseCorrection(
+                originalAgentResponse = "ten",
+                correctedAgentResponse = "ten fixed",
+                eventId = 10
+            )
+        )
+
+        val messages = handler.messages.value
+        assertEquals(listOf("ten fixed", "four"), messages.map { it.content })
+        assertEquals(listOf(10, 4), messages.map { it.eventId })
     }
 
     // --- User tentative (tentative_user_transcript) ---
@@ -185,13 +205,14 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `an out-of-order user_transcript with a stale event id is ignored`() = runTest {
+    fun `an out-of-order user_transcript is still recorded in arrival order`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "current", eventId = 20))
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 10))
+        // A finalized transcript is canonical: a lower (out-of-order) event id is kept, not dropped.
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "earlier", eventId = 10))
 
-        val message = handler.messages.value.single()
-        assertEquals("current", message.content)
-        assertEquals(20, message.eventId)
+        val messages = handler.messages.value
+        assertEquals(listOf("current", "earlier"), messages.map { it.content })
+        assertEquals(listOf(20, 10), messages.map { it.eventId })
     }
 
     // --- Cross-role, local sends, ordering ---
@@ -219,11 +240,12 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `a locally typed message does not let a later stale transcript reappear`() = runTest {
+    fun `a locally typed message does not resurrect a stale tentative`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first", eventId = 10))
-        // The typed message carries no event id, so it must not lower the role's high-water mark.
+        // The typed message carries no event id, so it must not lower the role's high-water mark...
         handler.sendUserMessage("typed")
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "stale", eventId = 5))
+        // ...and a tentative for an older turn stays suppressed.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "stale", eventId = 5))
 
         val messages = handler.messages.value
         assertEquals(listOf("first", "typed"), messages.map { it.content })

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventHandlerMessagesTest.kt
@@ -14,11 +14,8 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Behavior of the reconciled transcript exposed via [ConversationEventHandler.messages].
- *
- * Incoming transcripts/responses are matched per role by event id: a matching id updates the
- * existing message in place, a newer id appends, and a stale unmatched id is ignored. An
- * in-progress user partial never survives once its turn is finalized.
+ * Reconciliation of [ConversationEventHandler.messages]: a matching event id updates in place,
+ * finalized records always append (even out of order), and a user partial never outlives its turn.
  */
 class ConversationEventHandlerMessagesTest {
 
@@ -42,7 +39,7 @@ class ConversationEventHandlerMessagesTest {
         toolRegistry.cleanup()
     }
 
-    // --- Agent streaming (agent_chat_response_part) ---
+    // --- Agent streaming ---
 
     @Test
     fun `streaming agent parts accumulate into one message and finalize on stop`() = runTest {
@@ -74,10 +71,8 @@ class ConversationEventHandlerMessagesTest {
         assertFalse(message.isPartial)
     }
 
-    // --- Agent response / correction ---
-
     @Test
-    fun `agent_response finalizes a streaming partial in place`() = runTest {
+    fun `agent_response finalizes a still-streaming partial in place`() = runTest {
         handler.handleIncomingEvent(part("start", "Hi", 3))
 
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "Hi, how can I help?", eventId = 3))
@@ -87,50 +82,15 @@ class ConversationEventHandlerMessagesTest {
         assertFalse(message.isPartial)
     }
 
-    @Test
-    fun `agent_response_correction replaces the matching agent message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "It is sunny", eventId = 9))
-
-        handler.handleIncomingEvent(
-            ConversationEvent.AgentResponseCorrection(
-                originalAgentResponse = "It is sunny",
-                correctedAgentResponse = "It is raining",
-                eventId = 9
-            )
-        )
-
-        val message = handler.messages.value.single()
-        assertEquals("It is raining", message.content)
-        assertFalse(message.isPartial)
-    }
+    // --- Agent finalized records arrive out of order ---
 
     @Test
-    fun `agent_response with a newer event id appends a new message`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "first", eventId = 1))
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "second", eventId = 2))
-
-        val messages = handler.messages.value
-        assertEquals(listOf("first", "second"), messages.map { it.content })
-        assertEquals(listOf(1, 2), messages.map { it.eventId })
-    }
-
-    @Test
-    fun `an out-of-order agent_response is still recorded in arrival order`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "current", eventId = 10))
-        // A finalized response is canonical: a lower (out-of-order) event id is kept, not dropped.
-        handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "earlier", eventId = 4))
-
-        val messages = handler.messages.value
-        assertEquals(listOf("current", "earlier"), messages.map { it.content })
-        assertEquals(listOf(10, 4), messages.map { it.eventId })
-    }
-
-    @Test
-    fun `a correction matches an out-of-order event id without duplicating`() = runTest {
+    fun `an out-of-order correction updates the right agent message without duplicating`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "ten", eventId = 10))
+        // A lower id arrives late, so the list is no longer sorted by event id.
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "four", eventId = 4))
 
-        // id 10 now sits before id 4 in the list, so the matcher must scan past the lower id to find it.
+        // The matcher must scan past id 4 to find id 10 rather than appending a duplicate.
         handler.handleIncomingEvent(
             ConversationEvent.AgentResponseCorrection(
                 originalAgentResponse = "ten",
@@ -144,22 +104,22 @@ class ConversationEventHandlerMessagesTest {
         assertEquals(listOf(10, 4), messages.map { it.eventId })
     }
 
-    // --- User tentative (tentative_user_transcript) ---
-
     @Test
-    fun `tentative user transcripts for one turn collapse into a single partial`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hel", eventId = 5))
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello the", eventId = 5))
+    fun `an out-of-order user_transcript updates the right message without duplicating`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "twenty", eventId = 20))
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "ten", eventId = 10))
 
-        val message = handler.messages.value.single()
-        assertEquals(MessageRole.USER, message.role)
-        assertEquals("hello the", message.content)
-        assertTrue(message.isPartial)
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "twenty fixed", eventId = 20))
+
+        val messages = handler.messages.value
+        assertEquals(listOf("twenty fixed", "ten"), messages.map { it.content })
+        assertEquals(listOf(20, 10), messages.map { it.eventId })
     }
 
+    // --- User tentative / partial handling ---
+
     @Test
-    fun `a newer tentative replaces a stray partial instead of duplicating it`() = runTest {
-        // A tentative that never finalized, then a newer one: the stale partial must not linger.
+    fun `consecutive tentatives collapse into a single partial`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up.", eventId = 245))
         handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Set up a test.", eventId = 249))
 
@@ -170,17 +130,19 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `a tentative is ignored once the turn is finalized`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "hello there", eventId = 5))
-        // A stray tentative arriving after the final must not reopen a partial bubble.
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "hello th", eventId = 5))
+    fun `a tentative is gated by the highest event id, not the latest message`() = runTest {
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "q1", eventId = 20))
+        // A lower final id and a null-id typed message follow; neither lowers the high-water mark.
+        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "q2", eventId = 10))
+        handler.sendUserMessage("typed")
 
-        val message = handler.messages.value.single()
-        assertEquals("hello there", message.content)
-        assertFalse(message.isPartial)
+        // id 15 is below the highest recorded id (20), so the tentative must stay suppressed.
+        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "stale", eventId = 15))
+
+        val messages = handler.messages.value
+        assertEquals(listOf("q1", "q2", "typed"), messages.map { it.content })
+        assertTrue(messages.none { it.isPartial })
     }
-
-    // --- User transcript (final) ---
 
     @Test
     fun `user_transcript finalizes the in-progress partial`() = runTest {
@@ -194,7 +156,7 @@ class ConversationEventHandlerMessagesTest {
 
     @Test
     fun `user_transcript for a new turn appends and clears a stray partial`() = runTest {
-        // The id-468 partial never finalized; the next turn's final (id 475) must drop it.
+        // The id-468 partial never finalized; the next turn's final must drop it, not leave a bubble.
         handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "Any questions?", eventId = 468))
         handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "I have one.", eventId = 475))
 
@@ -204,18 +166,7 @@ class ConversationEventHandlerMessagesTest {
         assertFalse(message.isPartial)
     }
 
-    @Test
-    fun `an out-of-order user_transcript is still recorded in arrival order`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "current", eventId = 20))
-        // A finalized transcript is canonical: a lower (out-of-order) event id is kept, not dropped.
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "earlier", eventId = 10))
-
-        val messages = handler.messages.value
-        assertEquals(listOf("current", "earlier"), messages.map { it.content })
-        assertEquals(listOf(20, 10), messages.map { it.eventId })
-    }
-
-    // --- Cross-role, local sends, ordering ---
+    // --- Cross-role, local sends, end to end ---
 
     @Test
     fun `user and agent messages with the same event id stay distinct`() = runTest {
@@ -240,19 +191,6 @@ class ConversationEventHandlerMessagesTest {
     }
 
     @Test
-    fun `a locally typed message does not resurrect a stale tentative`() = runTest {
-        handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "first", eventId = 10))
-        // The typed message carries no event id, so it must not lower the role's high-water mark...
-        handler.sendUserMessage("typed")
-        // ...and a tentative for an older turn stays suppressed.
-        handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "stale", eventId = 5))
-
-        val messages = handler.messages.value
-        assertEquals(listOf("first", "typed"), messages.map { it.content })
-        assertEquals(listOf(10, null), messages.map { it.eventId })
-    }
-
-    @Test
     fun `a full voice turn reconciles streamed and finalized text into ordered messages`() = runTest {
         handler.handleIncomingEvent(ConversationEvent.TentativeUserTranscript(userTranscript = "what's the", eventId = 1))
         handler.handleIncomingEvent(ConversationEvent.UserTranscript(userTranscript = "what's the weather?", eventId = 1))
@@ -262,11 +200,8 @@ class ConversationEventHandlerMessagesTest {
         handler.handleIncomingEvent(ConversationEvent.AgentResponse(agentResponse = "It's sunny.", eventId = 2))
 
         val messages = handler.messages.value
-        assertEquals(2, messages.size)
-        assertEquals(MessageRole.USER, messages[0].role)
-        assertEquals("what's the weather?", messages[0].content)
-        assertEquals(MessageRole.AGENT, messages[1].role)
-        assertEquals("It's sunny.", messages[1].content)
+        assertEquals(listOf("what's the weather?", "It's sunny."), messages.map { it.content })
+        assertEquals(listOf(MessageRole.USER, MessageRole.AGENT), messages.map { it.role })
         assertTrue("no partial bubbles should remain", messages.none { it.isPartial })
     }
 

--- a/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventParserTest.kt
+++ b/elevenlabs-sdk/src/test/java/io/elevenlabs/ConversationEventParserTest.kt
@@ -277,6 +277,108 @@ class ConversationEventParserTest {
         assertTrue(toolCall.parameters.isEmpty())
     }
 
+    // ==================== Transcript event_id tests ====================
+
+    @Test
+    fun `agent_response should parse event_id`() {
+        val json = """
+            {
+                "type": "agent_response",
+                "agent_response_event": {
+                    "agent_response": "Hello",
+                    "event_id": 12
+                }
+            }
+        """.trimIndent()
+
+        val event = ConversationEventParser.parseIncomingEvent(json)
+
+        assertTrue(event is ConversationEvent.AgentResponse)
+        val agentResponse = event as ConversationEvent.AgentResponse
+        assertEquals("Hello", agentResponse.agentResponse)
+        assertEquals(12, agentResponse.eventId)
+    }
+
+    @Test
+    fun `user_transcript should parse event_id`() {
+        val json = """
+            {
+                "type": "user_transcript",
+                "user_transcription_event": {
+                    "user_transcript": "hello world",
+                    "event_id": 8
+                }
+            }
+        """.trimIndent()
+
+        val event = ConversationEventParser.parseIncomingEvent(json)
+
+        assertTrue(event is ConversationEvent.UserTranscript)
+        val userTranscript = event as ConversationEvent.UserTranscript
+        assertEquals("hello world", userTranscript.userTranscript)
+        assertEquals(8, userTranscript.eventId)
+    }
+
+    @Test
+    fun `agent_chat_response_part should parse event_id and type`() {
+        val json = """
+            {
+                "type": "agent_chat_response_part",
+                "text_response_part": {
+                    "text": "Hi",
+                    "type": "delta",
+                    "event_id": 3
+                }
+            }
+        """.trimIndent()
+
+        val event = ConversationEventParser.parseIncomingEvent(json)
+
+        assertTrue(event is ConversationEvent.AgentChatResponsePart)
+        val part = event as ConversationEvent.AgentChatResponsePart
+        assertEquals("Hi", part.text)
+        assertEquals("delta", part.partType)
+        assertEquals(3, part.eventId)
+    }
+
+    @Test
+    fun `agent_response_correction should parse event_id`() {
+        val json = """
+            {
+                "type": "agent_response_correction",
+                "agent_response_correction_event": {
+                    "original_agent_response": "sunny",
+                    "corrected_agent_response": "raining",
+                    "event_id": 21
+                }
+            }
+        """.trimIndent()
+
+        val event = ConversationEventParser.parseIncomingEvent(json)
+
+        assertTrue(event is ConversationEvent.AgentResponseCorrection)
+        val correction = event as ConversationEvent.AgentResponseCorrection
+        assertEquals("raining", correction.correctedAgentResponse)
+        assertEquals(21, correction.eventId)
+    }
+
+    @Test
+    fun `agent_response without event_id yields null event_id`() {
+        val json = """
+            {
+                "type": "agent_response",
+                "agent_response_event": {
+                    "agent_response": "Hello"
+                }
+            }
+        """.trimIndent()
+
+        val event = ConversationEventParser.parseIncomingEvent(json)
+
+        assertTrue(event is ConversationEvent.AgentResponse)
+        assertEquals(null, (event as ConversationEvent.AgentResponse).eventId)
+    }
+
     // ==================== Edge case tests ====================
 
     @Test

--- a/example-app/src/main/java/io/elevenlabs/example/MainActivity.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/MainActivity.kt
@@ -163,6 +163,7 @@ private fun AppRoot(viewModel: ConversationViewModel) {
                 mode = mode,
                 isMuted = isMuted ?: false,
                 canSendFeedback = canSendFeedback ?: false,
+                messages = messages,
                 onDisconnect = { viewModel.endConversation() },
                 onToggleMute = { viewModel.toggleMute() },
                 onSetVolume = { viewModel.setVolume(it) },

--- a/example-app/src/main/java/io/elevenlabs/example/models/TextChatModels.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/models/TextChatModels.kt
@@ -1,11 +1,12 @@
 package io.elevenlabs.example.models
 
 /**
- * Lightweight chat message used by the text chat surface. Populated for both voice and text-only
- * sessions so the same transcript view can render either modality.
+ * Lightweight chat message used by the text chat surface, mapped from the SDK's reconciled
+ * transcript. [id] is the SDK message id, stable across partial/final updates so it works as a
+ * list key.
  */
 data class TextChatMessage(
-    val id: Long,
+    val id: String,
     val content: String,
     val isFromUser: Boolean,
 )

--- a/example-app/src/main/java/io/elevenlabs/example/ui/TextChatScreen.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/ui/TextChatScreen.kt
@@ -142,7 +142,7 @@ private fun ChatHeader(
 }
 
 @Composable
-private fun MessageList(
+internal fun MessageList(
     messages: List<TextChatMessage>,
     isAgentTyping: Boolean,
     modifier: Modifier = Modifier,
@@ -385,9 +385,9 @@ private fun TextChatScreenPreview() {
         TextChatScreen(
             status = ConversationStatus.CONNECTED,
             messages = listOf(
-                TextChatMessage(1, "Hello, what can you do?", isFromUser = true),
+                TextChatMessage("1", "Hello, what can you do?", isFromUser = true),
                 TextChatMessage(
-                    2,
+                    "2",
                     "I can help you explore ElevenLabs Conversational AI.",
                     isFromUser = false
                 ),

--- a/example-app/src/main/java/io/elevenlabs/example/ui/VoiceScreen.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/ui/VoiceScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.elevenlabs.example.R
+import io.elevenlabs.example.models.TextChatMessage
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
 
@@ -51,9 +52,9 @@ private val DisconnectedGray = Color(0xFF9CA3AF)
 private val ErrorRed = Color(0xFFEF4444)
 
 /**
- * Voice-mode controls: status, mute, volume, feedback, mode indicator, and a composer for sending
- * contextual updates or text user messages over the active session. Owns its own Disconnect
- * action — there is no shared header.
+ * Voice-mode controls: status, mute, volume, feedback, mode indicator, a live transcript, and a
+ * composer for sending contextual updates or text user messages over the active session. Owns its
+ * own Disconnect action — there is no shared header.
  */
 @Composable
 fun VoiceScreen(
@@ -61,6 +62,7 @@ fun VoiceScreen(
     mode: ConversationMode?,
     isMuted: Boolean,
     canSendFeedback: Boolean,
+    messages: List<TextChatMessage>,
     onDisconnect: () -> Unit,
     onToggleMute: () -> Unit,
     onSetVolume: (Float) -> Unit,
@@ -145,6 +147,10 @@ fun VoiceScreen(
                 ) { Text("👎") }
             }
 
+            if (messages.isNotEmpty()) {
+                Transcript(messages = messages)
+            }
+
             MessageComposer(
                 value = input,
                 onValueChange = { input = it },
@@ -198,6 +204,33 @@ private fun ModeIndicator(mode: ConversationMode?) {
         )
         Spacer(Modifier.size(8.dp))
         Text(text = label, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun Transcript(
+    messages: List<TextChatMessage>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Transcript",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(8.dp))
+        // Bounded height + own scroll so the transcript doesn't crowd out the controls below.
+        MessageList(
+            messages = messages,
+            isAgentTyping = false,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(260.dp)
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                    RoundedCornerShape(12.dp),
+                ),
+        )
     }
 }
 
@@ -267,6 +300,10 @@ private fun VoiceScreenPreviewListening() {
             mode = ConversationMode.LISTENING,
             isMuted = false,
             canSendFeedback = true,
+            messages = listOf(
+                TextChatMessage("1", "Hey, can you hear me?", isFromUser = true),
+                TextChatMessage("2", "Loud and clear. How can I help?", isFromUser = false),
+            ),
             onDisconnect = {},
             onToggleMute = {},
             onSetVolume = {},
@@ -287,6 +324,7 @@ private fun VoiceScreenPreviewSpeakingMuted() {
             mode = ConversationMode.SPEAKING,
             isMuted = true,
             canSendFeedback = false,
+            messages = emptyList(),
             onDisconnect = {},
             onToggleMute = {},
             onSetVolume = {},
@@ -307,6 +345,7 @@ private fun VoiceScreenPreviewConnecting() {
             mode = null,
             isMuted = false,
             canSendFeedback = false,
+            messages = emptyList(),
             onDisconnect = {},
             onToggleMute = {},
             onSetVolume = {},

--- a/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
@@ -13,16 +13,17 @@ import io.elevenlabs.example.models.TextChatMessage
 import io.elevenlabs.example.models.UiState
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
+import io.elevenlabs.models.Message
+import io.elevenlabs.models.MessageRole
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
- * Single ViewModel covering both voice and text-only conversations. The same SDK callbacks feed
- * a shared transcript so a UI can render either modality (voice controls, chat bubbles, or both)
- * from one source of truth.
+ * Single ViewModel covering both voice and text-only conversations. The transcript is the SDK's
+ * reconciled [io.elevenlabs.ConversationSession.messages], mapped to the UI model, so chat bubbles
+ * render the same source of truth for either modality.
  */
 class ConversationViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -69,15 +70,12 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
         _mutedSpeechEvent.postValue(null)
     }
 
-    // Chat transcript — populated for both voice (via onUserTranscript / onAgentResponse) and
-    // text-only (via sendUserMessage + onAgentResponse) sessions.
+    // Chat transcript, mapped from the SDK's reconciled ConversationSession.messages.
     private val _messages = MutableStateFlow<List<TextChatMessage>>(emptyList())
     val messages: StateFlow<List<TextChatMessage>> = _messages.asStateFlow()
 
     private val _isAgentTyping = MutableStateFlow(false)
     val isAgentTyping: StateFlow<Boolean> = _isAgentTyping.asStateFlow()
-
-    private var nextMessageId: Long = 1L
 
     fun startConversation(activityContext: Context, textOnly: Boolean) {
         if (currentSession != null && _uiState.value != UiState.Idle && _uiState.value !is UiState.Error) {
@@ -150,14 +148,12 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                     },
                     onUserTranscript = { transcript ->
                         Log.d(TAG, "onUserTranscript: $transcript")
-                        appendUserMessage(transcript)
                     },
                     onAudioAlignment = { alignment ->
                         Log.d(TAG, "onAudioAlignment: $alignment")
                     },
                     onAgentResponse = { response ->
                         Log.d(TAG, "onAgentResponse: $response")
-                        appendAgentText(response)
                     },
                     onAgentResponseMetadata = { metadata ->
                         Log.d(TAG, "onAgentResponseMetadata: $metadata")
@@ -212,6 +208,16 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                 viewModelScope.launch {
                     session.isMuted.collect { muted ->
                         _isMuted.postValue(muted)
+                    }
+                }
+
+                // Render the SDK's reconciled transcript, mapped to the UI model.
+                viewModelScope.launch {
+                    session.messages.collect { sdkMessages ->
+                        _messages.value = sdkMessages.map { it.toTextChatMessage() }
+                        // Show the typing indicator while the newest turn is the user's; once the
+                        // agent starts streaming, its partial bubble takes over.
+                        _isAgentTyping.value = sdkMessages.lastOrNull()?.role == MessageRole.USER
                     }
                 }
 
@@ -303,14 +309,13 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
             return
         }
         try {
+            // The SDK appends the local user bubble to its transcript, which we collect above.
             session.sendUserMessage(trimmed)
         } catch (t: Throwable) {
             Log.d(TAG, "Failed to send user message: ${t.message}")
             _errorMessage.postValue(t.localizedMessage ?: "Send failed")
             return
         }
-        appendUserMessage(trimmed)
-        _isAgentTyping.value = true
     }
 
     fun sendUserActivity() {
@@ -343,37 +348,13 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
     private fun resetTranscript() {
         _messages.value = emptyList()
         _isAgentTyping.value = false
-        nextMessageId = 1L
     }
 
-    private fun appendUserMessage(text: String) {
-        if (text.isBlank()) return
-        _messages.update { it + TextChatMessage(nextMessageId++, text, isFromUser = true) }
-    }
-
-    /**
-     * Append agent text to the latest agent bubble or start a new bubble if the previous message
-     * was from the user. Three SDK events funnel into onAgentResponse — streaming deltas, tentative
-     * partials, and a final consolidated message — so dedup against the full bubble content rather
-     * than appending blindly.
-     */
-    private fun appendAgentText(text: String) {
-        if (text.isEmpty()) return
-        _messages.update { current ->
-            val last = current.lastOrNull()
-            if (last == null || last.isFromUser) {
-                return@update current + TextChatMessage(nextMessageId++, text, isFromUser = false)
-            }
-            val updated = when {
-                last.content == text -> last
-                text.startsWith(last.content) -> last.copy(content = text)
-                else -> last.copy(content = last.content + text)
-            }
-            if (updated === last) current
-            else current.toMutableList().also { it[it.lastIndex] = updated }
-        }
-        _isAgentTyping.value = false
-    }
+    private fun Message.toTextChatMessage() = TextChatMessage(
+        id = id,
+        content = content,
+        isFromUser = role == MessageRole.USER,
+    )
 
     override fun onCleared() {
         super.onCleared()


### PR DESCRIPTION
## Summary

Rendering chat history is a challenging and brittle task today - we have different overlapping server-sent events which make the reconciliation logic non-trivial, and on top of that, we use the same `onAgentResponse()` callback for different types of events without providing any indication of the type of event.

This PR introduces `messages: StateFlow<List<TextChatMessage>>` which holds the reconciled list of messages that the host app can consume to avoid having to implement convoluted reconciliation logic.

(I'm going to address `onAgentResponse()` callback issues in a separate PR, it doesn't affect how `messages` works)


Summary of reconciliation logic:

* Agent Response:
  * full agent response and agent response correction
    * if there's an existing message with matching event_id: replace it
    * else: append to the end of `messages`
  * agent response part
    * if there is an existing message with matching event id:
      * if the existing message is partial: append to the existing message
      * else: ignore - the existing message is already a complete message
    * else if its event_id is greater than any previous event_ids:  append to the end of `messages` as a partial message
    * else: ignore - this is unexpected, better to wait for the full response


* User Transcript:
  * tentative user transcript - they come with full text and different event_ids while the user speaks, so we should only keep the latest one and discard all previous ones. If it has a fresh event_id, we append it to the end of the list, otherwise ignore
  * final user transcript - if there's a tentative user transcript with matching event id, we replace it, otherwise append to the end of the list

## Testing

* Updated the example app to use `messages` and tested manually
* Unit tests