### PR TITLE
Deprecate text/agent callbacks in favor of event-id variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,19 @@ val config = ConversationConfig(
         // Agent audio level (volume), range from 0.0 to 1.0
         // Log.d("MyApp", "Agent audio level: $level")
     },
-    onUserTranscript = { transcript ->
-        // User's speech transcribed to text
+    onUserTranscriptEvent = { text, eventId ->
+        // User's speech transcribed to text (finalized)
     },
-    onAgentResponse = { response ->
-        // Agent's text response
+    onTentativeUserTranscriptEvent = { text, eventId ->
+        // In-progress user transcript
     },
-    onAgentResponseCorrection = { originalResponse, correctedResponse ->
+    onAgentResponseEvent = { text, eventId ->
+        // Agent's finalized text response
+    },
+    onAgentResponsePartEvent = { partType, text, eventId ->
+        // Streaming agent text part: AgentResponsePartType.START / DELTA / STOP
+    },
+    onAgentResponseCorrectionEvent = { text, eventId ->
         // Agent response was corrected after interruption
     },
     onAgentToolResponse = { toolName, toolCallId, toolType, isError ->
@@ -214,7 +220,7 @@ val session = ConversationClient.startSession(
     ConversationConfig(
         agentId = "<your_public_agent_id>",
         textOnly = true,
-        onAgentResponse = { reply -> /* render reply */ },
+        onAgentResponseEvent = { reply, _ -> /* render reply */ },
     ),
     this,
 )
@@ -290,10 +296,14 @@ Both parameters are optional and default to the standard ElevenLabs production e
 
 ### Conversation Event Callbacks
 
-- **onUserTranscript(transcript: String)**: User's speech transcribed to text in real-time.
-- **onAgentResponse(response: String)**: Agent's text response before it's converted to speech.
-- **onAgentResponseCorrection(originalResponse: String, correctedResponse: String)**: Agent response was corrected after user interruption.
+- **onUserTranscriptEvent(text: String, eventId: Int?)**: Finalized user transcript for a turn, with its server event id.
+- **onTentativeUserTranscriptEvent(text: String, eventId: Int?)**: In-progress user transcript, updated as recognition refines.
+- **onAgentResponseEvent(text: String, eventId: Int?)**: Agent's finalized text response for a turn, with its server event id.
+- **onAgentResponsePartEvent(partType: AgentResponsePartType, text: String, eventId: Int?)**: Streaming agent text parts. `partType` is `START`, `DELTA`, or `STOP`.
+- **onAgentResponseCorrectionEvent(text: String, eventId: Int?)**: Corrected agent response (after user interruption), with its server event id.
 - **onInterruption(eventId: Int)**: User interrupted the agent while speaking.
+
+> **Deprecated:** `onUserTranscript(transcript: String)`, `onAgentResponse(response: String)`, and `onAgentResponseCorrection(originalResponse: String, correctedResponse: String)` are superseded by the `…Event` callbacks above, which also surface the server event id. They still fire for backward compatibility.
 
 ### Tool & Feedback Callbacks
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
@@ -1,5 +1,6 @@
 package io.elevenlabs
 
+import io.elevenlabs.models.AgentResponsePartType
 import io.elevenlabs.models.ConversationEvent.ClientToolCall
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
@@ -77,9 +78,22 @@ data class ConversationConfig(
     val onAudioLevelChanged: ((level: Float) -> Unit)? = null,
     val onAudioAlignment: ((alignment: Map<String, Any>) -> Unit)? = null,
     val onAgentResponseMetadata: ((metadata: Map<String, Any>) -> Unit)? = null,
+    @Deprecated("Use onUserTranscriptEvent, which also reports the server event id.")
     val onUserTranscript: ((userTranscript: String) -> Unit)? = null,
+    @Deprecated("Use onAgentResponseEvent, which also reports the server event id.")
     val onAgentResponse: ((agentResponse: String) -> Unit)? = null,
+    @Deprecated("Use onAgentResponseCorrectionEvent, which reports the corrected text and its event id.")
     val onAgentResponseCorrection: ((originalResponse: String, correctedResponse: String) -> Unit)? = null,
+    // Finalized user transcript for a turn, with its server event id.
+    val onUserTranscriptEvent: ((text: String, eventId: Int?) -> Unit)? = null,
+    // In-progress user transcript, with its server event id.
+    val onTentativeUserTranscriptEvent: ((text: String, eventId: Int?) -> Unit)? = null,
+    // Finalized agent response for a turn, with its server event id.
+    val onAgentResponseEvent: ((text: String, eventId: Int?) -> Unit)? = null,
+    // Streaming agent response part (start/delta/stop), with its server event id.
+    val onAgentResponsePartEvent: ((partType: AgentResponsePartType, text: String, eventId: Int?) -> Unit)? = null,
+    // Corrected agent response (after interruption), with its server event id.
+    val onAgentResponseCorrectionEvent: ((text: String, eventId: Int?) -> Unit)? = null,
     val onAgentToolResponse: ((toolName: String, toolCallId: String, toolType: String, isError: Boolean) -> Unit)? = null,
     val onConversationInitiationMetadata: ((conversationId: String, agentOutputFormat: String, userInputFormat: String) -> Unit)? = null,
     val onInterruption: ((eventId: Int) -> Unit)? = null,

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationEventHandler.kt
@@ -27,6 +27,11 @@ class ConversationEventHandler(
     private val onUserTranscript: ((String) -> Unit)? = null,
     private val onAgentResponse: ((String) -> Unit)? = null,
     private val onAgentResponseCorrection: ((String, String) -> Unit)? = null,
+    private val onUserTranscriptEvent: ((String, Int?) -> Unit)? = null,
+    private val onTentativeUserTranscriptEvent: ((String, Int?) -> Unit)? = null,
+    private val onAgentResponseEvent: ((String, Int?) -> Unit)? = null,
+    private val onAgentResponsePartEvent: ((AgentResponsePartType, String, Int?) -> Unit)? = null,
+    private val onAgentResponseCorrectionEvent: ((String, Int?) -> Unit)? = null,
     private val onAgentToolResponse: ((String, String, String, Boolean) -> Unit)? = null,
     private val onConversationInitiationMetadata: ((String, String, String) -> Unit)? = null,
     private val onInterruption: ((Int) -> Unit)? = null,
@@ -85,6 +90,10 @@ class ConversationEventHandler(
     private suspend fun handleAgentChatResponsePart(event: ConversationEvent.AgentChatResponsePart) {
         appendAgentResponsePart(text = event.text, eventId = event.eventId, isStop = event.partType == "stop")
 
+        AgentResponsePartType.fromString(event.partType)?.let { partType ->
+            try { onAgentResponsePartEvent?.invoke(partType, event.text, event.eventId) } catch (_: Throwable) {}
+        }
+
         when (event.partType) {
             "start" -> {
                 _conversationMode.value = ConversationMode.SPEAKING
@@ -109,6 +118,7 @@ class ConversationEventHandler(
     private suspend fun handleTentativeUserTranscript(event: ConversationEvent.TentativeUserTranscript) {
         applyTentativeUserTranscript(content = event.userTranscript, eventId = event.eventId)
         try { onUserTranscript?.invoke(event.userTranscript) } catch (_: Throwable) {}
+        try { onTentativeUserTranscriptEvent?.invoke(event.userTranscript, event.eventId) } catch (_: Throwable) {}
     }
 
     /**
@@ -158,6 +168,11 @@ class ConversationEventHandler(
         } catch (e: Exception) {
             Log.e("ConvEventHandler", "Error in onAgentResponse callback: ${e.message}", e)
         }
+        try {
+            onAgentResponseEvent?.invoke(event.agentResponse, event.eventId)
+        } catch (e: Exception) {
+            Log.e("ConvEventHandler", "Error in onAgentResponseEvent callback: ${e.message}", e)
+        }
     }
 
     /**
@@ -170,6 +185,11 @@ class ConversationEventHandler(
         } catch (e: Exception) {
             Log.e("ConvEventHandler", "Error in onUserTranscript callback: ${e.message}", e)
         }
+        try {
+            onUserTranscriptEvent?.invoke(event.userTranscript, event.eventId)
+        } catch (e: Exception) {
+            Log.e("ConvEventHandler", "Error in onUserTranscriptEvent callback: ${e.message}", e)
+        }
     }
 
     private fun handleAgentResponseCorrection(event: ConversationEvent.AgentResponseCorrection) {
@@ -178,6 +198,11 @@ class ConversationEventHandler(
             onAgentResponseCorrection?.invoke(event.originalAgentResponse, event.correctedAgentResponse)
         } catch (e: Exception) {
             Log.e("ConvEventHandler", "Error in onAgentResponseCorrection callback: ${e.message}", e)
+        }
+        try {
+            onAgentResponseCorrectionEvent?.invoke(event.correctedAgentResponse, event.eventId)
+        } catch (e: Exception) {
+            Log.e("ConvEventHandler", "Error in onAgentResponseCorrectionEvent callback: ${e.message}", e)
         }
     }
 

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationSessionImpl.kt
@@ -33,7 +33,9 @@ internal class ConversationSessionImpl(
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     @Volatile private var conversationId: String? = null
 
-    // Event handler for processing conversation events
+    // Event handler for processing conversation events.
+    // The deprecated config callbacks are intentionally bridged here for back-compat.
+    @Suppress("DEPRECATION")
     private val eventHandler = ConversationEventHandler(
         audioManager = audioManager,
         toolRegistry = toolRegistry,
@@ -64,6 +66,21 @@ internal class ConversationSessionImpl(
         },
         onAgentResponseCorrection = { original, corrected ->
             try { config.onAgentResponseCorrection?.invoke(original, corrected) } catch (_: Throwable) {}
+        },
+        onUserTranscriptEvent = { text, eventId ->
+            try { config.onUserTranscriptEvent?.invoke(text, eventId) } catch (_: Throwable) {}
+        },
+        onTentativeUserTranscriptEvent = { text, eventId ->
+            try { config.onTentativeUserTranscriptEvent?.invoke(text, eventId) } catch (_: Throwable) {}
+        },
+        onAgentResponseEvent = { text, eventId ->
+            try { config.onAgentResponseEvent?.invoke(text, eventId) } catch (_: Throwable) {}
+        },
+        onAgentResponsePartEvent = { partType, text, eventId ->
+            try { config.onAgentResponsePartEvent?.invoke(partType, text, eventId) } catch (_: Throwable) {}
+        },
+        onAgentResponseCorrectionEvent = { text, eventId ->
+            try { config.onAgentResponseCorrectionEvent?.invoke(text, eventId) } catch (_: Throwable) {}
         },
         onAgentToolResponse = { toolName, toolCallId, toolType, isError ->
             try { config.onAgentToolResponse?.invoke(toolName, toolCallId, toolType, isError) } catch (_: Throwable) {}

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
@@ -181,3 +181,22 @@ sealed class ConversationEvent {
     ) : ConversationEvent()
 
 }
+
+/**
+ * Lifecycle position of a streamed agent chat response part.
+ */
+enum class AgentResponsePartType {
+    START,
+    DELTA,
+    STOP;
+
+    companion object {
+        /** Maps a raw value ("start" | "delta" | "stop") to its enum, or null if unrecognized. */
+        fun fromString(value: String): AgentResponsePartType? = when (value) {
+            "start" -> START
+            "delta" -> DELTA
+            "stop" -> STOP
+            else -> null
+        }
+    }
+}

--- a/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
@@ -146,20 +146,26 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                         // Commented out as it's quite noisy
                         // Log.d(TAG, "audioLevel: $level")
                     },
-                    onUserTranscript = { transcript ->
-                        Log.d(TAG, "onUserTranscript: $transcript")
+                    onUserTranscriptEvent = { transcript, eventId ->
+                        Log.d(TAG, "onUserTranscript: text='$transcript', eventId=$eventId")
+                    },
+                    onTentativeUserTranscriptEvent = { transcript, eventId ->
+                        Log.d(TAG, "onTentativeUserTranscript: text='$transcript', eventId=$eventId")
                     },
                     onAudioAlignment = { alignment ->
                         Log.d(TAG, "onAudioAlignment: $alignment")
                     },
-                    onAgentResponse = { response ->
-                        Log.d(TAG, "onAgentResponse: $response")
+                    onAgentResponseEvent = { response, eventId ->
+                        Log.d(TAG, "onAgentResponse: text='$response', eventId=$eventId")
+                    },
+                    onAgentResponsePartEvent = { partType, text, eventId ->
+                        Log.d(TAG, "onAgentResponsePart: partType=$partType, text='$text', eventId=$eventId")
                     },
                     onAgentResponseMetadata = { metadata ->
                         Log.d(TAG, "onAgentResponseMetadata: $metadata")
                     },
-                    onAgentResponseCorrection = { originalResponse, correctedResponse ->
-                        Log.d(TAG, "onAgentResponseCorrection: original='$originalResponse', corrected='$correctedResponse'")
+                    onAgentResponseCorrectionEvent = { correctedResponse, eventId ->
+                        Log.d(TAG, "onAgentResponseCorrection: corrected='$correctedResponse', eventId=$eventId")
                     },
                     onAgentToolResponse = { toolName, toolCallId, toolType, isError ->
                         Log.d(TAG, "onAgentToolResponse: tool=$toolName, callId=$toolCallId, type=$toolType, isError=$isError")


### PR DESCRIPTION
(duplicate of this PR which got merged into a wrong branch: https://github.com/elevenlabs/elevenlabs-android/pull/57)

Add five callbacks that also surface the server event id (and, for streaming agent text, a typed AgentResponsePartType):
- onUserTranscriptEvent / onTentativeUserTranscriptEvent
- onAgentResponseEvent / onAgentResponsePartEvent / onAgentResponseCorrectionEvent

The existing onUserTranscript / onAgentResponse / onAgentResponseCorrection callbacks are kept and marked @Deprecated; both old and new fire side-by-side for backward compatibility. Migrate the example app and README to the new API.

