### PR TITLE
bump version to 0.10.0

### DIFF
--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.elevenlabs"
-version = "0.9.1"
+version = "0.10.0"
 
 android {
 namespace = "io.elevenlabs"


### PR DESCRIPTION
## Summary
Bump SDK version to `0.10.0`.
Changes since `0.9.1`:
- [#56](https://github.com/elevenlabs/elevenlabs-android/pull/56) adds `ConversationSession.messages`, a reconciled `StateFlow<List<Message>>` transcript managed by the SDK, plus message reconciliation tests and example app updates.
- [#58](https://github.com/elevenlabs/elevenlabs-android/pull/58) adds event-id-aware transcript and agent callbacks, including streaming agent response parts, while deprecating the older callbacks with backward compatibility.