### PR TITLE
Add audio frame callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ val config = ConversationConfig(
         // Agent audio level (volume), range from 0.0 to 1.0
         // Log.d("MyApp", "Agent audio level: $level")
     },
+    onAudioFrame = { frame ->
+        // Decoded PCM chunk from the agent's audio track (little-endian).
+        // The ByteBuffer is only valid for the duration of this callback — copy what you need.
+        // Useful for visualizations, recording, or custom DSP.
+    },
     onUserTranscriptEvent = { text, eventId ->
         // User's speech transcribed to text (finalized)
     },
@@ -315,6 +320,7 @@ Both parameters are optional and default to the standard ElevenLabs production e
 
 - **onVadScore(score: Float)**: Voice Activity Detection score. Ranges from 0 to 1 where higher values indicate confidence of speech.
 - **onAudioLevelChanged(level: Float)**: Agent audio level (volume) in real-time. Ranges from 0.0 (silent) to 1.0 (loudest). Typically shows small variations during speech.
+- **onAudioFrame(frame: AudioFrame)**: Decoded PCM chunks from the agent's remote audio track, delivered as they arrive. `AudioFrame` exposes `audioData: ByteBuffer` (little-endian PCM), `bitsPerSample`, `sampleRate`, `channelCount`, `numberOfFrames`, and `absoluteCaptureTimestampMs`. The `ByteBuffer` is only valid for the duration of the callback — copy the bytes if you need to keep them. Useful for waveform visualizations, recording, or custom audio processing. The callback runs on LiveKit's audio thread, so keep work short and avoid blocking.
 - **onConversationInitiationMetadata(conversationId: String, agentOutputFormat: String, userInputFormat: String)**: Conversation metadata including audio format details.
 
 ---

--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.elevenlabs"
-version = "0.10.0"
+version = "0.10.1"
 
 android {
 namespace = "io.elevenlabs"

--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.elevenlabs"
-version = "0.10.1"
+version = "0.11"
 
 android {
 namespace = "io.elevenlabs"

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationConfig.kt
@@ -1,5 +1,6 @@
 package io.elevenlabs
 
+import io.elevenlabs.models.AudioFrame
 import io.elevenlabs.models.AgentResponsePartType
 import io.elevenlabs.models.ConversationEvent.ClientToolCall
 import io.elevenlabs.models.ConversationMode
@@ -76,6 +77,7 @@ data class ConversationConfig(
     val onUnhandledClientToolCall: ((ClientToolCall) -> Unit)? = null,
     val onVadScore: ((score: Float) -> Unit)? = null,
     val onAudioLevelChanged: ((level: Float) -> Unit)? = null,
+    val onAudioFrame: ((frame: AudioFrame) -> Unit)? = null,
     val onAudioAlignment: ((alignment: Map<String, Any>) -> Unit)? = null,
     val onAgentResponseMetadata: ((metadata: Map<String, Any>) -> Unit)? = null,
     @Deprecated("Use onUserTranscriptEvent, which also reports the server event id.")

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/AudioFrame.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/AudioFrame.kt
@@ -1,0 +1,30 @@
+package io.elevenlabs.models
+
+import java.nio.ByteBuffer
+
+/**
+ * One decoded PCM chunk from the agent's remote audio track, delivered immediately before
+ * playback. Use this to drive amplitude-reactive UI (e.g. a voice orb) in sample-accurate sync
+ * with what the user hears.
+ *
+ * Delivered via [io.elevenlabs.ConversationConfig.onAudioFrame] on WebRTC's audio thread,
+ * typically every 10 ms. Implementations must not block.
+ *
+ * The [audioData] buffer is a read-only view owned by WebRTC and is only valid for the duration
+ * of the callback — copy any bytes that need to outlive the call.
+ *
+ * @param audioData PCM samples, little-endian. Position/limit are set to the sample range.
+ * @param bitsPerSample Sample width — 16 (signed integer) or 32 (float).
+ * @param sampleRate Samples per second, e.g. 48000.
+ * @param channelCount 1 for mono, 2 for stereo.
+ * @param numberOfFrames Sample frames in this buffer (one frame = [channelCount] samples).
+ * @param absoluteCaptureTimestampMs Wall-clock capture timestamp as reported by WebRTC.
+ */
+data class AudioFrame(
+    val audioData: ByteBuffer,
+    val bitsPerSample: Int,
+    val sampleRate: Int,
+    val channelCount: Int,
+    val numberOfFrames: Int,
+    val absoluteCaptureTimestampMs: Long,
+)

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/AudioFrame.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/AudioFrame.kt
@@ -3,22 +3,8 @@ package io.elevenlabs.models
 import java.nio.ByteBuffer
 
 /**
- * One decoded PCM chunk from the agent's remote audio track, delivered immediately before
- * playback. Use this to drive amplitude-reactive UI (e.g. a voice orb) in sample-accurate sync
- * with what the user hears.
- *
- * Delivered via [io.elevenlabs.ConversationConfig.onAudioFrame] on WebRTC's audio thread,
- * typically every 10 ms. Implementations must not block.
- *
- * The [audioData] buffer is a read-only view owned by WebRTC and is only valid for the duration
- * of the callback — copy any bytes that need to outlive the call.
- *
- * @param audioData PCM samples, little-endian. Position/limit are set to the sample range.
- * @param bitsPerSample Sample width — 16 (signed integer) or 32 (float).
- * @param sampleRate Samples per second, e.g. 48000.
- * @param channelCount 1 for mono, 2 for stereo.
- * @param numberOfFrames Sample frames in this buffer (one frame = [channelCount] samples).
- * @param absoluteCaptureTimestampMs Wall-clock capture timestamp as reported by WebRTC.
+ * One decoded PCM chunk from the agent's remote audio track. [audioData] is little-endian and
+ * only valid for the duration of the callback — copy what you need.
  */
 data class AudioFrame(
     val audioData: ByteBuffer,

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/WebRTCConnection.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/WebRTCConnection.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import livekit.org.webrtc.AudioTrackSink
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.util.Collections
 import io.elevenlabs.ConversationOverridesBuilder
 
@@ -60,9 +61,6 @@ class WebRTCConnection(
     private var messageJob: Job? = null
     private var audioLevelJob: Job? = null
 
-    // Forwards per-frame PCM from each subscribed remote audio track to
-    // [ConversationConfig.onAudioFrame]. Tracked so we can detach cleanly on unsubscribe /
-    // disconnect.
     private val agentAudioSinks: MutableMap<RemoteAudioTrack, AudioTrackSink> =
         Collections.synchronizedMap(mutableMapOf())
 
@@ -309,9 +307,6 @@ class WebRTCConnection(
         when (track) {
             is RemoteAudioTrack -> {
                 Log.d("WebRTCConnection", "Audio track subscribed from ${participant.sid}")
-                // Audio tracks are automatically played by LiveKit. Additionally tap raw PCM
-                // for any caller that wired onAudioFrame so they can drive amplitude-
-                // reactive UI in sync with playback.
                 attachAgentAudioSink(track)
             }
             else -> {
@@ -467,14 +462,6 @@ class WebRTCConnection(
         scope.cancel()
     }
 
-    /**
-     * WebRTC sink wrapped around [ConversationConfig.onAudioFrame]. One instance per
-     * subscribed remote audio track. Resolves the callback lazily via [callback] so updating
-     * [latestConfig] mid-session is picked up automatically.
-     *
-     * `onData` is invoked on WebRTC's audio thread; the wrapped callback is responsible for
-     * not blocking it.
-     */
     private class AudioFrameSink(
         private val callback: () -> ((AudioFrame) -> Unit)?,
     ) : AudioTrackSink {
@@ -488,7 +475,7 @@ class WebRTCConnection(
         ) {
             val cb = callback() ?: return
             val frame = AudioFrame(
-                audioData = audioData,
+                audioData = audioData.order(ByteOrder.LITTLE_ENDIAN),
                 bitsPerSample = bitsPerSample,
                 sampleRate = sampleRate,
                 channelCount = numberOfChannels,

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/WebRTCConnection.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/WebRTCConnection.kt
@@ -3,6 +3,7 @@ package io.elevenlabs.network
 import android.content.Context
 import android.util.Log
 import io.elevenlabs.ConversationConfig
+import io.elevenlabs.models.AudioFrame
 import io.elevenlabs.models.ConversationMode
 import io.elevenlabs.models.ConversationStatus
 import io.elevenlabs.models.DisconnectionDetails
@@ -19,7 +20,9 @@ import io.livekit.android.events.collect
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
+import livekit.org.webrtc.AudioTrackSink
 import java.nio.ByteBuffer
+import java.util.Collections
 import io.elevenlabs.ConversationOverridesBuilder
 
 
@@ -56,6 +59,12 @@ class WebRTCConnection(
     private val messageChannel = Channel<String>(Channel.UNLIMITED)
     private var messageJob: Job? = null
     private var audioLevelJob: Job? = null
+
+    // Forwards per-frame PCM from each subscribed remote audio track to
+    // [ConversationConfig.onAudioFrame]. Tracked so we can detach cleanly on unsubscribe /
+    // disconnect.
+    private val agentAudioSinks: MutableMap<RemoteAudioTrack, AudioTrackSink> =
+        Collections.synchronizedMap(mutableMapOf())
 
     /**
      * Connect to LiveKit room using the WebRTC token from [config] and the given server URL.
@@ -111,6 +120,9 @@ class WebRTCConnection(
             // Stop audio level monitoring
             audioLevelJob?.cancel()
             audioLevelJob = null
+
+            // Detach any agent audio sinks before the room tears the tracks down
+            detachAllAgentAudioSinks()
 
             // Stop event handling
             eventHandlerJob?.cancel()
@@ -250,6 +262,11 @@ class WebRTCConnection(
                         handleTrackSubscribed(event.track, event.participant)
                     }
 
+                    is RoomEvent.TrackUnsubscribed -> {
+                        Log.d("WebRTCConnection", "Track unsubscribed from ${event.participant.sid}")
+                        handleTrackUnsubscribed(event.track)
+                    }
+
                     is RoomEvent.DataReceived -> {
                         handleDataReceived(event.data, event.participant)
                     }
@@ -292,10 +309,55 @@ class WebRTCConnection(
         when (track) {
             is RemoteAudioTrack -> {
                 Log.d("WebRTCConnection", "Audio track subscribed from ${participant.sid}")
-                // Audio tracks are automatically played by LiveKit
+                // Audio tracks are automatically played by LiveKit. Additionally tap raw PCM
+                // for any caller that wired onAudioFrame so they can drive amplitude-
+                // reactive UI in sync with playback.
+                attachAgentAudioSink(track)
             }
             else -> {
                 Log.d("WebRTCConnection", "Other track type subscribed: ${track.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun handleTrackUnsubscribed(track: Track) {
+        if (track is RemoteAudioTrack) detachAgentAudioSink(track)
+    }
+
+    private fun attachAgentAudioSink(track: RemoteAudioTrack) {
+        synchronized(agentAudioSinks) {
+            if (agentAudioSinks.containsKey(track)) return
+            val sink = AudioFrameSink { latestConfig?.onAudioFrame }
+            agentAudioSinks[track] = sink
+            try {
+                track.addSink(sink)
+            } catch (t: Throwable) {
+                agentAudioSinks.remove(track)
+                Log.d("WebRTCConnection", "Failed to attach agent audio sink: ${t.message}")
+            }
+        }
+    }
+
+    private fun detachAgentAudioSink(track: RemoteAudioTrack) {
+        synchronized(agentAudioSinks) {
+            val sink = agentAudioSinks.remove(track) ?: return
+            try {
+                track.removeSink(sink)
+            } catch (t: Throwable) {
+                Log.d("WebRTCConnection", "Failed to detach agent audio sink: ${t.message}")
+            }
+        }
+    }
+
+    private fun detachAllAgentAudioSinks() {
+        val snapshot = synchronized(agentAudioSinks) {
+            agentAudioSinks.toMap().also { agentAudioSinks.clear() }
+        }
+        snapshot.forEach { (track, sink) ->
+            try {
+                track.removeSink(sink)
+            } catch (t: Throwable) {
+                Log.d("WebRTCConnection", "Failed to detach agent audio sink: ${t.message}")
             }
         }
     }
@@ -403,5 +465,41 @@ class WebRTCConnection(
     fun cleanup() {
         disconnect()
         scope.cancel()
+    }
+
+    /**
+     * WebRTC sink wrapped around [ConversationConfig.onAudioFrame]. One instance per
+     * subscribed remote audio track. Resolves the callback lazily via [callback] so updating
+     * [latestConfig] mid-session is picked up automatically.
+     *
+     * `onData` is invoked on WebRTC's audio thread; the wrapped callback is responsible for
+     * not blocking it.
+     */
+    private class AudioFrameSink(
+        private val callback: () -> ((AudioFrame) -> Unit)?,
+    ) : AudioTrackSink {
+        override fun onData(
+            audioData: ByteBuffer,
+            bitsPerSample: Int,
+            sampleRate: Int,
+            numberOfChannels: Int,
+            numberOfFrames: Int,
+            absoluteCaptureTimestampMs: Long,
+        ) {
+            val cb = callback() ?: return
+            val frame = AudioFrame(
+                audioData = audioData,
+                bitsPerSample = bitsPerSample,
+                sampleRate = sampleRate,
+                channelCount = numberOfChannels,
+                numberOfFrames = numberOfFrames,
+                absoluteCaptureTimestampMs = absoluteCaptureTimestampMs,
+            )
+            try {
+                cb(frame)
+            } catch (t: Throwable) {
+                Log.d("WebRTCConnection", "onAudioFrame callback threw: ${t.message}")
+            }
+        }
     }
 }

--- a/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
@@ -146,6 +146,9 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                         // Commented out as it's quite noisy
                         // Log.d(TAG, "audioLevel: $level")
                     },
+                    onAudioFrame = { frame ->
+                        // Log.d(TAG, "onAudioFrame: ${frame.numberOfFrames} frames @ ${frame.sampleRate}Hz")
+                    },
                     onUserTranscriptEvent = { transcript, eventId ->
                         Log.d(TAG, "onUserTranscript: text='$transcript', eventId=$eventId")
                     },


### PR DESCRIPTION
This PR adds audio frame callbacks to the android SDK. this helps us process the PCM data and animate the new voice orbs in ElevenReader in conversations with agents.